### PR TITLE
Add support to 4.13

### DIFF
--- a/Source/UnrealCV/Private/CaptureManager.cpp
+++ b/Source/UnrealCV/Private/CaptureManager.cpp
@@ -15,9 +15,9 @@ void FCaptureManager::AttachGTCaptureComponentToCamera(APawn* Pawn)
 	SupportedModes.Add(TEXT("depth"));
 	SupportedModes.Add(TEXT("debug"));
 	SupportedModes.Add(TEXT("object_mask"));
-	SupportedModes.Add(TEXT("normal")); 
+	SupportedModes.Add(TEXT("normal"));
 	SupportedModes.Add(TEXT("wireframe"));
-	SupportedModes.Add(TEXT("default")); 
+	SupportedModes.Add(TEXT("default"));
 	// TODO: Get the list from GTCaptureComponent
 
 	CaptureComponentList.Empty();
@@ -28,21 +28,6 @@ void FCaptureManager::AttachGTCaptureComponentToCamera(APawn* Pawn)
 	UGTCaptureComponent* RightEye = UGTCaptureComponent::Create(Pawn, SupportedModes);
 	RightEye->AddLocalOffset(FVector(0, 40, 0)); // TODO: make this configurable
 	CaptureComponentList.Add(RightEye);
-}
-
-APawn* GetFirstPawn()
-{
-	static UWorld* CurrentWorld = nullptr;
-	static APawn* Pawn = nullptr;
-	if (Pawn == nullptr || CurrentWorld != GWorld)
-	{
-		APlayerController* PlayerController = GWorld->GetFirstPlayerController();
-		check(PlayerController);
-		Pawn = PlayerController->GetPawn();
-		check(Pawn);
-		CurrentWorld = GWorld;
-	}
-	return Pawn;
 }
 
 UGTCaptureComponent* FCaptureManager::GetCamera(int32 CameraId)

--- a/Source/UnrealCV/Private/ObjectPainter.cpp
+++ b/Source/UnrealCV/Private/ObjectPainter.cpp
@@ -201,7 +201,8 @@ TMap<FString, AActor*>& FObjectPainter::GetObjectsMapping()
 
 bool FObjectPainter::PaintRandomColors()
 {
-	FSceneViewport* SceneViewport = GWorld->GetGameViewport()->GetGameViewport();
+	UWorld* World = FUE4CVServer::Get().GetGameWorld();
+	FSceneViewport* SceneViewport = World->GetGameViewport()->GetGameViewport();
 	/*
 	float Gamma = SceneViewport->GetDisplayGamma();
 	check(Gamma != 0);

--- a/Source/UnrealCV/Private/PlayerViewMode.cpp
+++ b/Source/UnrealCV/Private/PlayerViewMode.cpp
@@ -10,19 +10,20 @@
 
 DECLARE_DELEGATE(ViewModeFunc)
 
-FPlayerViewMode::FPlayerViewMode() : CurrentViewMode("lit") 
+FPlayerViewMode::FPlayerViewMode() : CurrentViewMode("lit")
 {
 }
 
 APostProcessVolume* FPlayerViewMode::GetPostProcessVolume()
 {
+	UWorld* World = FUE4CVServer::Get().GetGameWorld();
 	static APostProcessVolume* PostProcessVolume = nullptr;
 	static UWorld* CurrentWorld = nullptr; // Check whether the world has been restarted.
-	if (PostProcessVolume == nullptr || CurrentWorld != GWorld)
+	if (PostProcessVolume == nullptr || CurrentWorld != World)
 	{
-		PostProcessVolume = GWorld->SpawnActor<APostProcessVolume>();
+		PostProcessVolume = World->SpawnActor<APostProcessVolume>();
 		PostProcessVolume->bUnbound = true;
-		CurrentWorld = GWorld;
+		CurrentWorld = World;
 	}
 	return PostProcessVolume;
 }
@@ -59,7 +60,8 @@ void FPlayerViewMode::SetCurrentBufferVisualizationMode(FString ViewMode)
 
 void FPlayerViewMode::DepthWorldUnits()
 {
-	UGameViewportClient* Viewport = GWorld->GetGameViewport();
+	UWorld* World = FUE4CVServer::Get().GetGameWorld();
+	UGameViewportClient* Viewport = World->GetGameViewport();
 	FViewMode::BufferVisualization(Viewport->EngineShowFlags);
 	SetCurrentBufferVisualizationMode(TEXT("SceneDepthWorldUnits"));
 }
@@ -81,14 +83,16 @@ void FPlayerViewMode::BaseColor()
 
 void FPlayerViewMode::Lit()
 {
+	UWorld* World = FUE4CVServer::Get().GetGameWorld();
 	this->ClearPostProcess();
-	auto Viewport = GWorld->GetGameViewport();
+	auto Viewport = World->GetGameViewport();
 	FViewMode::Lit(Viewport->EngineShowFlags);
 }
 
 void FPlayerViewMode::Unlit()
 {
-	auto Viewport = GWorld->GetGameViewport();
+	UWorld* World = FUE4CVServer::Get().GetGameWorld();
+	auto Viewport = World->GetGameViewport();
 	FViewMode::Unlit(Viewport->EngineShowFlags);
 }
 
@@ -99,7 +103,8 @@ void FPlayerViewMode::ClearPostProcess()
 
 void FPlayerViewMode::ApplyPostProcess(FString ModeName)
 {
-	UGameViewportClient* GameViewportClient = GWorld->GetGameViewport();
+	UWorld* World = FUE4CVServer::Get().GetGameWorld();
+	UGameViewportClient* GameViewportClient = World->GetGameViewport();
 	FSceneViewport* SceneViewport = GameViewportClient->GetGameViewport();
 
 	FViewMode::PostProcess(GameViewportClient->EngineShowFlags);
@@ -121,7 +126,8 @@ void FPlayerViewMode::DebugMode()
 // TODO: Clean up this messy function.
 void PaintObjects()
 {
-	APlayerController* PlayerController = GWorld->GetFirstPlayerController();
+	UWorld* World = FUE4CVServer::Get().GetGameWorld();
+	APlayerController* PlayerController = World->GetFirstPlayerController();
 	check(PlayerController);
 	APawn* Pawn = PlayerController->GetPawn();
 	check(Pawn);
@@ -132,13 +138,15 @@ void PaintObjects()
 void FPlayerViewMode::Object()
 {
 	PaintObjects();
-	auto Viewport = GWorld->GetGameViewport();
+	UWorld* World = FUE4CVServer::Get().GetGameWorld();
+	auto Viewport = World->GetGameViewport();
 	FViewMode::VertexColor(Viewport->EngineShowFlags);
 	// ApplyPostProcess("object_mask");
 }
 
 FExecStatus FPlayerViewMode::SetMode(const TArray<FString>& Args) // Check input arguments
 {
+	UWorld* World = FUE4CVServer::Get().GetGameWorld();
 	UE_LOG(LogUnrealCV, Warning, TEXT("Run SetMode %s"), *Args[0]);
 
 	static TMap<FString, ViewModeFunc>* ViewModeHandlers;
@@ -154,7 +162,7 @@ FExecStatus FPlayerViewMode::SetMode(const TArray<FString>& Args) // Check input
 		ViewModeHandlers->Add(TEXT("unlit"), ViewModeFunc::CreateRaw(this, &FPlayerViewMode::Unlit));
 		ViewModeHandlers->Add(TEXT("base_color"), ViewModeFunc::CreateRaw(this, &FPlayerViewMode::BaseColor));
 		ViewModeHandlers->Add(TEXT("debug"), ViewModeFunc::CreateRaw(this, &FPlayerViewMode::DebugMode));
-		ViewModeHandlers->Add(TEXT("wireframe"), ViewModeFunc::CreateLambda([]() { FViewMode::Wireframe(GWorld->GetGameViewport()->EngineShowFlags);  }));
+		ViewModeHandlers->Add(TEXT("wireframe"), ViewModeFunc::CreateLambda([World]() { FViewMode::Wireframe(World->GetGameViewport()->EngineShowFlags);  }));
 	}
 
 	// Check args

--- a/Source/UnrealCV/Private/ScreenCapture.cpp
+++ b/Source/UnrealCV/Private/ScreenCapture.cpp
@@ -140,7 +140,8 @@ FExecStatus GetCameraViewSync(const FString& FullFilename)
 	// This can only work within editor
 	// Reimplement a GameViewportClient is required according to the discussion from here
 	// https://forums.unrealengine.com/showthread.php?50857-FViewPort-ReadPixels-crash-while-play-on-quot-standalone-Game-quot-mode
-	UGameViewportClient* ViewportClient = GWorld->GetGameViewport();
+	UWorld* World = FUE4CVServer::Get().GetGameWorld();
+	UGameViewportClient* ViewportClient = World->GetGameViewport();
 	if (DoCaptureScreen(ViewportClient, FullFilename))
 	{
 		return FExecStatus::OK(FullFilename);

--- a/Source/UnrealCV/Private/UE4CVServer.cpp
+++ b/Source/UnrealCV/Private/UE4CVServer.cpp
@@ -14,13 +14,14 @@ APawn* FUE4CVServer::GetPawn()
 {
 	static APawn* Pawn = nullptr;
 	static UWorld* CurrentWorld = nullptr;
-	if (Pawn == nullptr || CurrentWorld != GWorld)
+	UWorld* World = GetGameWorld();
+	if (Pawn == nullptr || CurrentWorld != World)
 	{
-		APlayerController* PlayerController = GWorld->GetFirstPlayerController();
+		APlayerController* PlayerController = World->GetFirstPlayerController();
 		check(PlayerController);
 		Pawn = PlayerController->GetPawn();
 		check(Pawn);
-		CurrentWorld = GWorld;
+		CurrentWorld = World;
 	}
 	return Pawn;
 }
@@ -94,22 +95,21 @@ UWorld* FUE4CVServer::GetGameWorld()
 	check(false);
 	return World;
 }
-	
+
 
 /**
  * Make sure the UE4CVServer is correctly configured.
  */
 void FUE4CVServer::InitGWorld()
 {
+	UWorld *World = GetGameWorld();
 	// Use this to replace BeginPlay()
 	static UWorld *CurrentWorld = nullptr;
-	if (CurrentWorld != GWorld) 
+	if (CurrentWorld != World)
 	{
-		UWorld* World = GetGameWorld();
-
 		// Invoke this everytime when the GWorld changes
 		// This will happen when the game is stopped and restart in the UE4Editor
-		// APlayerController* PlayerController = GWorld->GetFirstPlayerController();
+		// APlayerController* PlayerController = World->GetFirstPlayerController();
 		APlayerController* PlayerController = World->GetFirstPlayerController();
 		check(PlayerController);
 		APawn* Pawn = PlayerController->GetPawn();
@@ -119,7 +119,7 @@ void FUE4CVServer::InitGWorld()
 
 		FCaptureManager::Get().AttachGTCaptureComponentToCamera(Pawn);
 
-		CurrentWorld = GWorld;
+		CurrentWorld = World;
 	}
 }
 

--- a/Source/UnrealCV/Private/UE4CVServer.cpp
+++ b/Source/UnrealCV/Private/UE4CVServer.cpp
@@ -7,6 +7,7 @@
 #include "CameraHandler.h"
 #include "ObjectHandler.h"
 #include "PluginHandler.h"
+#include "UnrealEd.h"
 
 /** Only available during game play */
 APawn* FUE4CVServer::GetPawn()
@@ -70,6 +71,31 @@ FUE4CVServer::~FUE4CVServer()
 	// this->NetworkManager->FinishDestroy(); // TODO: Check is this usage correct?
 }
 
+UWorld* FUE4CVServer::GetGameWorld()
+{
+	// The correct way to get GameWorld;
+	UEditorEngine* EditorEngine = Cast<UEditorEngine>(GEngine); // TODO: check which macro can determine whether I am in editor
+	UWorld* World = nullptr;
+	if (EditorEngine != nullptr)
+	{
+		World = EditorEngine->PlayWorld;
+		check(World->IsGameWorld());
+		return World;
+	}
+
+	UGameEngine* GameEngine = Cast<UGameEngine>(GEngine);
+	if (GameEngine != nullptr)
+	{
+		World = GameEngine->GetGameWorld();
+		check(World->IsGameWorld());
+		return World;
+	}
+
+	check(false);
+	return World;
+}
+	
+
 /**
  * Make sure the UE4CVServer is correctly configured.
  */
@@ -79,9 +105,12 @@ void FUE4CVServer::InitGWorld()
 	static UWorld *CurrentWorld = nullptr;
 	if (CurrentWorld != GWorld) 
 	{
+		UWorld* World = GetGameWorld();
+
 		// Invoke this everytime when the GWorld changes
 		// This will happen when the game is stopped and restart in the UE4Editor
-		APlayerController* PlayerController = GWorld->GetFirstPlayerController();
+		// APlayerController* PlayerController = GWorld->GetFirstPlayerController();
+		APlayerController* PlayerController = World->GetFirstPlayerController();
 		check(PlayerController);
 		APawn* Pawn = PlayerController->GetPawn();
 		check(Pawn);

--- a/Source/UnrealCV/Public/UE4CVServer.h
+++ b/Source/UnrealCV/Public/UE4CVServer.h
@@ -78,6 +78,9 @@ public:
 	void RegisterCommandHandlers();
 
 	void InitGWorld();
+
+	/** Return the GameWorld of the editor or the game */
+	UWorld* GetGameWorld();
 private:
 	TArray<FCommandHandler*> CommandHandlers;
 

--- a/Source/UnrealCV/UnrealCV.Build.cs
+++ b/Source/UnrealCV/UnrealCV.Build.cs
@@ -35,7 +35,7 @@ namespace UnrealBuildTool.Rules
 				}
 				);
 
-            PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "RenderCore", "Networking", "Sockets", "Slate", "ImageWrapper"});
+            PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "RenderCore", "Networking", "Sockets", "Slate", "ImageWrapper", "UnrealEd"});
             /*
 			PublicDependencyModuleNames.AddRange(
 				new string[]


### PR DESCRIPTION
Fix issues caused by upgrading to 4.13.

The issues are caused by:
1. Bugfix: Fixed issues with FSocketBSD::Recv returning false on SE_EWOULDBLOCK when polling a non-blocking socket.
2. Removed GWorld from the Timer Manager.

See: https://docs.unrealengine.com/latest/INT/Support/Builds/ReleaseNotes/2016/4_13/index.html