### PR TITLE
Make python build automation consider /Users/Shared/EpicGames/ for engine path

### DIFF
--- a/client/python/unrealcv/automation.py
+++ b/client/python/unrealcv/automation.py
@@ -139,7 +139,10 @@ class UE4Automation:
             os.path.expanduser('~/UnrealEngine'),
             os.path.expanduser('~/workspace/UnrealEngine'),
             os.path.expanduser('~/workspace/UE4??'),]
-        mac_candidates = ['/Users/Shared/Epic Games/UE_4.??',]
+        mac_candidates = [
+            '/Users/Shared/Epic Games/UE_4.??',
+            '/Users/Shared/EpicGames/UE_4.??',
+            ]
         search_candidates = {'Linux': linux_candidates, 'Mac': mac_candidates, 'Win64': win_candidates}
         candidates = search_candidates.get(self._get_platform_name())
 


### PR DESCRIPTION
Because there still to be problems with building on the Mac
when there is a space in the UE4 engine path (see issue #61),
the easiest fix is to install without the space. This change
simply adds this path to the end of the mac_candidates list
for automatically finding the UE4 directory.