### PR TITLE
Implemented vset /action/game/resume.

### DIFF
--- a/Source/UnrealCV/Private/Commands/ActionHandler.cpp
+++ b/Source/UnrealCV/Private/Commands/ActionHandler.cpp
@@ -27,12 +27,9 @@ void FActionCommandHandler::RegisterCommands()
 	Help = "Set the distance of binocular stereo camera";
 	CommandDispatcher->BindCommand("vset /action/eyes_distance [float]", Cmd, Help);
 
-	
-	/*
 	Cmd = FDispatcherDelegate::CreateRaw(this, &FActionCommandHandler::ResumeGame);
 	Help = "Resume the game";
 	CommandDispatcher->BindCommand("vset /action/game/resume", Cmd, Help);
-	*/
 
 	Cmd = FDispatcherDelegate::CreateRaw(this, &FActionCommandHandler::Keyboard);
 	Help = "Send a keyboard action to the game";
@@ -43,6 +40,13 @@ FExecStatus FActionCommandHandler::PauseGame(const TArray<FString>& Args)
 {
 	APlayerController* PlayerController = this->GetWorld()->GetFirstPlayerController();
 	PlayerController->Pause();
+	return FExecStatus::OK();
+}
+
+FExecStatus FActionCommandHandler::ResumeGame(const TArray<FString>& Args)
+{
+	APlayerController* PlayerController = this->GetWorld()->GetFirstPlayerController();
+	PlayerController->SetPause(false);
 	return FExecStatus::OK();
 }
 

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -130,6 +130,9 @@ vset /action/keyboard [key_name] [delta]
 vset /action/game/pause
     (v0.3.10) Pause the game
 
+vset /action/game/resume
+    (v0.3.10) Resume the game
+
 vset /action/game/level [level_name]
     (v0.3.10) Open a new level
 


### PR DESCRIPTION
Pausing and unpausing games can be useful for taking multiple snapshots of the same frame as mentioned in [this issue](https://github.com/unrealcv/unrealcv/issues/116).
While pausing was already implemented, the implementation for resuming was still missing.

Resume/unpause had to be implemented in a slightly different way than pause: While for pausing, we could use the Pause() method of the PlayerController, there was no direct Unpause/Resume method. [SetPause(false)](https://api.unrealengine.com/INT/API/Runtime/Engine/GameFramework/APlayerController/SetPause/index.html) did the trick.