### PR TITLE
terminate script if UE4 location not found

### DIFF
--- a/client/python/unrealcv/automation.py
+++ b/client/python/unrealcv/automation.py
@@ -149,6 +149,7 @@ class UE4Automation:
         if len(found_UE4) == 1: return found_UE4[0]
         if len(found_UE4) == 0:
             print('Can not automatically found a UE4 path, please specify it with --UE4')
+            exit()
 
         print('Found UE4 in the following path, please make a selection:')
         print('\n'.join('%d : %s' % (i+1, found_UE4[i]) for i in range(len(found_UE4))))


### PR DESCRIPTION
Adding just one line to reduce possible confusion in locating Unreal Engine. This is in the client Python package.

If the user doesn't provide a path to UE4 and the path can't be found, the automation.py script in the Python package will continue anyways, causing an error later on. This fix prevents that from happening.