### PR TITLE
commented unreferenced variable definition

### DIFF
--- a/Source/UnrealCV/Private/Sensor/TextureReader.cpp
+++ b/Source/UnrealCV/Private/Sensor/TextureReader.cpp
@@ -142,7 +142,7 @@ bool ResizeFastReadTexture2DAsync(FTexture2DRHIRef Texture2D, int TargetWidth, i
 		TShaderMapRef<FScreenVS> VertexShader(ShaderMap);
 		TShaderMapRef<FScreenPS> PixelShader(ShaderMap);
 
-		static FGlobalBoundShaderState BoundShaderState;
+// 		static FGlobalBoundShaderState BoundShaderState;
 		// SetGlobalBoundShaderState(RHICmdList, FeatureLevel, BoundShaderState, RendererModule->GetFilterVertexDeclaration().VertexDeclarationRHI, *VertexShader, *PixelShader);
 
 		if (TargetSize != FIntPoint(SrcTexture->GetSizeX(), SrcTexture->GetSizeY()))


### PR DESCRIPTION
commented unreferenced variable definition that causes build failure.

This issue is mentioned here: https://github.com/unrealcv/unrealcv/issues/173

and it proves useful. 