### PR TITLE
fix: cpp code to be compatible with 4.27

### DIFF
--- a/.vs/ProjectSettings.json
+++ b/.vs/ProjectSettings.json
@@ -1,0 +1,3 @@
+{
+  "CurrentProjectSetting": "No Configurations"
+}

--- a/.vs/VSWorkspaceState.json
+++ b/.vs/VSWorkspaceState.json
@@ -1,0 +1,14 @@
+{
+  "ExpandedNodes": [
+    "",
+    "\\Source",
+    "\\Source\\UnrealCV",
+    "\\Source\\UnrealCV\\Public",
+    "\\Source\\UnrealCV\\Public\\Actor",
+    "\\Source\\UnrealCV\\Public\\Component",
+    "\\Source\\UnrealCV\\Public\\Sensor",
+    "\\Source\\UnrealCV\\Public\\Sensor\\CameraSensor"
+  ],
+  "SelectedNode": "\\Source\\UnrealCV\\Public\\Actor\\StereoCameraActor.h",
+  "PreviewInSolutionExplorer": false
+}

--- a/Source/UnrealCV/Public/Actor/StereoCameraActor.h
+++ b/Source/UnrealCV/Public/Actor/StereoCameraActor.h
@@ -17,7 +17,7 @@ public:
 
 	virtual void BeginPlay() override;
 
-	UPROPERTY(EditInstanceOnly)
+	UPROPERTY(EditInstanceOnly, Category = "unrealcv")
 	float BaselineDistance;
 
 	virtual TArray<FString> GetSensorNames() override;

--- a/Source/UnrealCV/Public/Component/KeypointComponent.h
+++ b/Source/UnrealCV/Public/Component/KeypointComponent.h
@@ -40,19 +40,19 @@ class UKeypointComponent : public USceneComponent
 public:
 	UKeypointComponent(const FObjectInitializer& ObjectInitializer);
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "unrealcv")
 	FString JsonFilename;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "unrealcv")
 	bool bVisualize;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "unrealcv")
 	float VisualizePointSize;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "unrealcv")
 	bool bMatchNearestVertex;
 	
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "unrealcv")
 	bool bDrawKeypointName;
 
 	UFUNCTION(BlueprintPure, Category = "unrealcv")

--- a/Source/UnrealCV/Public/Sensor/CameraSensor/DepthCamSensor.h
+++ b/Source/UnrealCV/Public/Sensor/CameraSensor/DepthCamSensor.h
@@ -17,6 +17,6 @@ public:
 
 	virtual void InitTextureTarget(int FilmWidth, int FilmHeight) override;
 
-	UPROPERTY(EditInstanceOnly)
+	UPROPERTY(EditInstanceOnly, Category = "unrealcv")
 	bool bIgnoreTransparentObjects;
 };

--- a/Source/UnrealCV/Public/Sensor/CameraSensor/FusionCamSensor.h
+++ b/Source/UnrealCV/Public/Sensor/CameraSensor/FusionCamSensor.h
@@ -1,6 +1,7 @@
 // Weichao Qiu @ 2017
 #pragma once
 
+#include "Runtime/Engine/Classes/Camera/CameraTypes.h"
 #include "Runtime/Engine/Classes/Components/PrimitiveComponent.h"
 #include "FusionCamSensor.generated.h"
 
@@ -115,32 +116,32 @@ public:
 #endif
 
 private:
-	UPROPERTY(EditInstanceOnly, meta=(AllowPrivateAccess = "true"))
+	UPROPERTY(EditInstanceOnly, meta=(AllowPrivateAccess = "true"), Category = "unrealcv")
 	EPresetFilmSize PresetFilmSize;
 
-	UPROPERTY(EditInstanceOnly, meta=(AllowPrivateAccess = "true"))
+	UPROPERTY(EditInstanceOnly, meta=(AllowPrivateAccess = "true"), Category = "unrealcv")
 	int FilmWidth;
 
-	UPROPERTY(EditInstanceOnly, meta=(AllowPrivateAccess = "true"))
+	UPROPERTY(EditInstanceOnly, meta=(AllowPrivateAccess = "true"), Category = "unrealcv")
 	int FilmHeight;
 
-	UPROPERTY(EditInstanceOnly, meta=(AllowPrivateAccess = "true"))
+	UPROPERTY(EditInstanceOnly, meta=(AllowPrivateAccess = "true"), Category = "unrealcv")
 	float FOV;
 
 protected:
 	UPROPERTY()
 	TArray<class UBaseCameraSensor*> FusionSensors;
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "unrealcv")
 	class UDepthCamSensor* DepthCamSensor;
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "unrealcv")
 	class UNormalCamSensor* NormalCamSensor;
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "unrealcv")
 	class UAnnotationCamSensor* AnnotationCamSensor;
 
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly, Category = "unrealcv")
 	class ULitCamSensor* LitCamSensor;
 
 	/** This preview camera is used for UE version < 4.17 which only support UCameraComponent PIP preview


### PR DESCRIPTION
The plugin can be successfully built following the ["Compile from source code" docs](http://docs.unrealcv.org/en/master/plugin/install.html) and is functional in UE 4.27.

Followed directions in #220 and #195 to solve:

1. **Error: An explicit Category specifier is required for any property exposed to the editor or Blueprints in an Engine module** by finding all the UPROPERTY() at locations of error and add a Category domain. e.g. `UPROPERTY(XXX, Category = "unrealcv")`
2.  **Error: use of undeclared identifier 'ECameraProjectionMode'** by adding `#include "Editor/UnrealEd/Classes/Editor/EditorEngine.h"` in Source/UnrealCV/Private/Server/UnrealcvServer.cpp

Test Environment:
- OS: Windows 10
- Unreal Engine: 4.27.2
- Visual Studio: VS2019 and VS2017, both set up following [the docs](https://docs.unrealengine.com/4.26/en-US/ProductionPipelines/DevelopmentSetup/VisualStudioSetup/)
- Python: 3.8.3