### PR TITLE
fixes for Unreal Engine 5.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 <!-- [![Build Status](https://travis-ci.org/unrealcv/unrealcv.svg?branch=master)](https://travis-ci.org/unrealcv/unrealcv) -->
 
-UnrealCV is a project to help computer vision researchers build virtual worlds using Unreal Engine 4 (UE4). It extends UE4 with a plugin by providing:
+UnrealCV is a project to help computer vision researchers build virtual worlds using Unreal Engine (UE). It extends UE with a plugin by providing:
 
 1. A set of UnrealCV commands to interact with the virtual world.
-2. Communication between UE4 and an external program, such as Caffe.
+2. Communication between UE and an external program, such as Caffe.
 
-UnrealCV can be used in two ways. The first one is using a compiled game binary with UnrealCV embedded. This is as simple as running a game, no knowledge of Unreal Engine is required. The second is installing UnrealCV plugin to Unreal Engine 4 (UE4) and use the editor of UE4 to build a new virtual world.
+UnrealCV can be used in two ways. The first one is using a compiled game binary with UnrealCV embedded. This is as simple as running a game, no knowledge of Unreal Engine is required. The second is installing the UnrealCV plugin into Unreal Engine and using the editor to build a new virtual world.
 
 
 Please read [Tutorial: Getting Started](http://unrealcv.github.io/tutorial/getting_started.html) to learn using UnrealCV.
@@ -28,7 +28,7 @@ Images generated from the technical demo <a href="http://docs.unrealcv.org/en/ma
 
 ## How to install UnrealCV
 To install the UnrealCV Server, you need:
-1. Download the source code and place it on the ``Plugin`` folder of a C++ UE4 project.
+1. Download the source code and place it on the ``Plugin`` folder of a C++ UE project.
 2. launch the C++ project with Visual Studio 2019, UnrealCV will be compiled at the same time.
 3. To check the success installation of UnrealCV, you can run ``vget /unrealcv/status`` in the console (Press **`** to display the console).
 

--- a/Source/UnrealCV/Private/BPFunctionLib/SensorBPLib.cpp
+++ b/Source/UnrealCV/Private/BPFunctionLib/SensorBPLib.cpp
@@ -27,7 +27,7 @@ TArray<UFusionCamSensor*> USensorBPLib::GetFusionSensorList()
 	TArray<UObject*> UObjectList;
 	bool bIncludeDerivedClasses = false;
 	EObjectFlags ExclusionFlags = EObjectFlags::RF_ClassDefaultObject;
-	EInternalObjectFlags ExclusionInternalFlags = EInternalObjectFlags::AllFlags;
+	EInternalObjectFlags ExclusionInternalFlags = EInternalObjectFlags_AllFlags;
 	GetObjectsOfClass(UFusionCamSensor::StaticClass(), UObjectList, bIncludeDerivedClasses, ExclusionFlags, ExclusionInternalFlags);
 
 	// Filter out objects not belong to the game world (editor world for example)

--- a/Source/UnrealCV/Private/BPFunctionLib/VisionBPLib.cpp
+++ b/Source/UnrealCV/Private/BPFunctionLib/VisionBPLib.cpp
@@ -140,7 +140,7 @@ void UVisionBPLib::SaveNpy(const TArray<float>& FloatData, int Width, int Height
 }
 
 void UVisionBPLib::GetBoneTransform(
-	const USkeletalMeshComponent* SkeletalMeshComponent,
+	USkeletalMeshComponent* SkeletalMeshComponent,
 	const TArray<FString>& IncludedBones,
 	TArray<FString>& BoneNames,
 	TArray<FTransform>& BoneTransforms,
@@ -166,7 +166,7 @@ void UVisionBPLib::GetBoneTransform(
 }
 
 void UVisionBPLib::GetBoneTransformJson(
-	const USkeletalMeshComponent* SkeletalMeshComponent,
+	USkeletalMeshComponent* SkeletalMeshComponent,
 	const TArray<FString>& IncludedBones,
 	TArray<FString>& BoneNames,
 	TArray<FJsonObjectBP>& BoneTransformsJson,
@@ -223,7 +223,7 @@ void UVisionBPLib::GetActorList(TArray<AActor*>& ActorList)
 	TArray<UObject*> UObjectList;
 	bool bIncludeDerivedClasses = true;
 	EObjectFlags ExclusionFlags = EObjectFlags::RF_ClassDefaultObject;
-	EInternalObjectFlags ExclusionInternalFlags = EInternalObjectFlags::AllFlags;
+	EInternalObjectFlags ExclusionInternalFlags = EInternalObjectFlags_AllFlags;
 	GetObjectsOfClass(AActor::StaticClass(), UObjectList, bIncludeDerivedClasses, ExclusionFlags, ExclusionInternalFlags);
 
 	for (UObject* ActorObject : UObjectList)

--- a/Source/UnrealCV/Private/Commands/ActionHandler.cpp
+++ b/Source/UnrealCV/Private/Commands/ActionHandler.cpp
@@ -1,6 +1,7 @@
 #include "ActionHandler.h"
 #include "Runtime/Engine/Classes/Engine/World.h"
 #include "Runtime/Engine/Classes/GameFramework/PlayerController.h"
+#include "Runtime/Engine/Classes/GameFramework/PlayerInput.h"
 #include "Runtime/Engine/Public/EngineUtils.h"
 #include "Runtime/Engine/Public/TimerManager.h"
 
@@ -138,9 +139,10 @@ FExecStatus FActionHandler::SetStereoDistance(const TArray<FString>& Args)
 /** Return a TFunction to Release the Keyboard */
 TFunction<void(void)> FActionHandler::GetReleaseKey(FKey Key)
 {
-	UWorld* World = this->GetWorld();
+	const UWorld* World = this->GetWorld();
 	return [=]() {
-		World->GetFirstPlayerController()->InputKey(Key, EInputEvent::IE_Released, 0, false);
+		FInputKeyParams KeyParams(Key, EInputEvent::IE_Released, 0, false);
+		World->GetFirstPlayerController()->InputKey(KeyParams);
 	};
 }
 
@@ -165,7 +167,8 @@ FExecStatus FActionHandler::Keyboard(const TArray<FString>& Args)
 	int32 NumSamples = 1;
 	bool bGamepad = false;
 	// The DeltaTime is not used in the code.
-	World->GetFirstPlayerController()->InputAxis(Key, Delta, DeltaTime, NumSamples, bGamepad);
+	FInputKeyParams KeyParams(Key, Delta, DeltaTime, NumSamples, bGamepad);
+	World->GetFirstPlayerController()->InputKey(KeyParams);
 	FTimerHandle TimerHandle;
 	World->GetTimerManager().SetTimer(TimerHandle, GetReleaseKey(Key), DeltaTime, false);
 

--- a/Source/UnrealCV/Private/Commands/AliasHandler.cpp
+++ b/Source/UnrealCV/Private/Commands/AliasHandler.cpp
@@ -205,7 +205,7 @@ FExecStatus FAliasHandler::VExecWithOutput(const TArray<FString>& Args)
 			{
 				bFoundDefault = true;
 
-				const TCHAR* Result = It->ImportText( *PropertyDefaultValue, It->ContainerPtrToValuePtr<uint8>(Parms), ExportFlags, NULL );
+				const TCHAR* Result = It->ImportText_Direct( *PropertyDefaultValue, It->ContainerPtrToValuePtr<uint8>(Parms), nullptr, ExportFlags);
 				bFailedImport = (Result == nullptr);
 			}
 		}
@@ -223,7 +223,7 @@ FExecStatus FAliasHandler::VExecWithOutput(const TArray<FString>& Args)
 				ArgStr = FString(RemainingStr).TrimStart(); // New API
 			}
 
-			const TCHAR* Result = It->ImportText(*ArgStr, It->ContainerPtrToValuePtr<uint8>(Parms), ExportFlags, NULL );
+			const TCHAR* Result = It->ImportText_Direct(*ArgStr, It->ContainerPtrToValuePtr<uint8>(Parms), nullptr, ExportFlags);
 			bFailedImport = (Result == nullptr);
 		}
 

--- a/Source/UnrealCV/Private/Commands/ObjectHandler.cpp
+++ b/Source/UnrealCV/Private/Commands/ObjectHandler.cpp
@@ -16,8 +16,9 @@
 
 FExecStatus SetActorName(AActor* Actor, FString NewName)
 {
-	UObject* NameScopeOuter = ANY_PACKAGE;
-	UObject* ExistingObject = StaticFindObject(/*Class=*/ NULL, NameScopeOuter, *NewName, true);
+	// UObject* NameScopeOuter = ANY_PACKAGE;
+	// UObject* ExistingObject = StaticFindObject(/*Class=*/ NULL, NameScopeOuter, *NewName, true);
+	UObject* ExistingObject = FindFirstObjectSafe<UObject>(*NewName);
 	if (IsValid(ExistingObject))
 	{
 		if (ExistingObject == Actor)
@@ -377,7 +378,7 @@ FExecStatus FObjectHandler::Spawn(const TArray<FString>& Args)
 		UClassName = Args[0]; 
 	}
 	// Lookup UClass with a string
-	UClass*	Class = FindObject<UClass>(ANY_PACKAGE, *UClassName);
+	UClass*	Class = FindFirstObjectSafe<UClass>(*UClassName);
 
 	if (!IsValid(Class))
 	{

--- a/Source/UnrealCV/Private/Component/AnnotationComponent.cpp
+++ b/Source/UnrealCV/Private/Component/AnnotationComponent.cpp
@@ -351,14 +351,14 @@ FPrimitiveSceneProxy* UAnnotationComponent::CreateSceneProxy(UStaticMeshComponen
 FPrimitiveSceneProxy* UAnnotationComponent::CreateSceneProxy(USkeletalMeshComponent* SkeletalMeshComponent)
 {
 	UMaterialInterface* ProxyMaterial = AnnotationMID; // Material Instance Dynamic
-	ERHIFeatureLevel::Type SceneFeatureLevel = GetWorld()->FeatureLevel;
+	// ERHIFeatureLevel::Type SceneFeatureLevel = GetWorld()->GetFeatureLevel();
 
 	// Ref: https://github.com/EpicGames/UnrealEngine/blob/4.19/Engine/Source/Runtime/Engine/Private/Components/SkinnedMeshComponent.cpp#L415
 	FSkeletalMeshRenderData* SkelMeshRenderData = SkeletalMeshComponent->GetSkeletalMeshRenderData();
 
 	// Only create a scene proxy for rendering if properly initialized
 	if (SkelMeshRenderData &&
-		SkelMeshRenderData->LODRenderData.IsValidIndex(SkeletalMeshComponent->PredictedLODLevel) &&
+		SkelMeshRenderData->LODRenderData.IsValidIndex(SkeletalMeshComponent->GetPredictedLODLevel()) &&
 		SkeletalMeshComponent->MeshObject) // The risk of using MeshObject
 	{
 		// Only create a scene proxy if the bone count being used is supported, or if we don't have a skeleton (this is the case with destructibles)

--- a/Source/UnrealCV/Private/Component/KeypointComponent.cpp
+++ b/Source/UnrealCV/Private/Component/KeypointComponent.cpp
@@ -119,12 +119,12 @@ TArray<FKeypoint> UKeypointComponent::LoadKeypointFromJson()
 	for (TSharedPtr<FJsonValue>& JsonValue : JsonArray)
 	{
 		const TSharedPtr<FJsonObject> JsonObject = JsonValue->AsObject();
-		double X = JsonObject->GetNumberField("x");
-		double Y = JsonObject->GetNumberField("y");
-		double Z = JsonObject->GetNumberField("z");
+		double X = JsonObject->GetNumberField(TEXT("x"));
+		double Y = JsonObject->GetNumberField(TEXT("y"));
+		double Z = JsonObject->GetNumberField(TEXT("z"));
 		FKeypoint Point;
 		Point.Location = FVector(X, Y, Z);
-		Point.Name = JsonObject->GetStringField("name");
+		Point.Name = JsonObject->GetStringField(TEXT("name"));
 		Points.Add(Point);
 	}
 	return Points;

--- a/Source/UnrealCV/Private/Controller/ObjectAnnotator.cpp
+++ b/Source/UnrealCV/Private/Controller/ObjectAnnotator.cpp
@@ -134,22 +134,26 @@ void FObjectAnnotator::CreateAnnotationComponent(AActor* Actor, const FColor& An
 		return;
 	}
 
-	UE_LOG(LogTemp, Log, TEXT("Annotate actor %s with color %s"), *Actor->GetName(), *AnnotationColor.ToString());
-	// UE_LOG(LogTemp, Log, TEXT("Annotate actor %s with color %s"), *Actor->GetName(), *AnnotationColor.ToString());
 	TArray<UActorComponent*> MeshComponents = Actor->K2_GetComponentsByClass(UMeshComponent::StaticClass());
-	for (UActorComponent* Component : MeshComponents)
+	if (MeshComponents.Num() > 0)
 	{
-		UMeshComponent* MeshComponent = Cast<UMeshComponent>(Component);
+		UE_LOG(LogTemp, Log, TEXT("Annotate actor %s (%s) with color %s"), *Actor->GetActorNameOrLabel(), *Actor->GetName(), *AnnotationColor.ToString());
 
-		UAnnotationComponent* AnnotationComponent = NewObject<UAnnotationComponent>(MeshComponent);
-		// UE_LOG(LogTemp, Log, TEXT("Annotate %s with color %s"), *MeshComponent->GetName(), *AnnotationColor.ToString());
-		AnnotationComponent->SetupAttachment(MeshComponent);
-		AnnotationComponent->RegisterComponent();
-		// Set annotation color after the component is registered
-		AnnotationComponent->SetAnnotationColor(AnnotationColor); 
-		AnnotationComponent->MarkRenderStateDirty();
+		for (UActorComponent* Component : MeshComponents)
+		{
+			UMeshComponent* MeshComponent = Cast<UMeshComponent>(Component);
+
+			UAnnotationComponent* AnnotationComponent = NewObject<UAnnotationComponent>(MeshComponent);
+			// UE_LOG(LogTemp, Log, TEXT("Annotate %s with color %s"), *MeshComponent->GetName(), *AnnotationColor.ToString());
+			AnnotationComponent->SetupAttachment(MeshComponent);
+			AnnotationComponent->RegisterComponent();
+			// Set annotation color after the component is registered
+			AnnotationComponent->SetAnnotationColor(AnnotationColor);
+			AnnotationComponent->MarkRenderStateDirty();
+		}
 	}
 }
+
 
 void FObjectAnnotator::UpdateAnnotationComponent(AActor* Actor, const FColor& AnnotationColor)
 {

--- a/Source/UnrealCV/Private/Controller/WorldController.cpp
+++ b/Source/UnrealCV/Private/Controller/WorldController.cpp
@@ -34,8 +34,9 @@ void AUnrealcvWorldController::AttachPawnSensor()
 	UPawnCamSensor* PawnCamSensor = NewObject<UPawnCamSensor>(Pawn, TEXT("PawnSensor")); // Make Pawn as the owner of the component
 	// UFusionCamSensor* FusionCamSensor = ConstructObject<UFusionCamSensor>(UFusionCamSensor::StaticClass(), Pawn);
 
-	UWorld *PawnWorld = Pawn->GetWorld(), *GameWorld = FUnrealcvServer::Get().GetWorld();
-	// check(Pawn->GetWorld() == FUnrealcvServer::GetWorld());
+	UWorld *PawnWorld = Pawn->GetWorld();
+	UWorld *GameWorld = FUnrealcvServer::Get().GetWorld();
+
 	check(PawnWorld == GameWorld);
 	PawnCamSensor->AttachToComponent(Pawn->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
 	// AActor* OwnerActor = FusionCamSensor->GetOwner();

--- a/Source/UnrealCV/Private/Controller/WorldController.cpp
+++ b/Source/UnrealCV/Private/Controller/WorldController.cpp
@@ -37,7 +37,9 @@ void AUnrealcvWorldController::AttachPawnSensor()
 	UWorld *PawnWorld = Pawn->GetWorld();
 	UWorld *GameWorld = FUnrealcvServer::Get().GetWorld();
 
+	check(IsValid(GameWorld));
 	check(PawnWorld == GameWorld);
+
 	PawnCamSensor->AttachToComponent(Pawn->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
 	// AActor* OwnerActor = FusionCamSensor->GetOwner();
 	PawnCamSensor->RegisterComponent(); // Is this neccessary?

--- a/Source/UnrealCV/Private/Sensor/BoneSensor.cpp
+++ b/Source/UnrealCV/Private/Sensor/BoneSensor.cpp
@@ -4,7 +4,7 @@
 #include "Runtime/Engine/Classes/Components/SkeletalMeshComponent.h"
 #include "Runtime/Engine/Public/AnimationRuntime.h"
 
-FBoneSensor::FBoneSensor(const USkeletalMeshComponent* InSkeletalMeshComponent)
+FBoneSensor::FBoneSensor(USkeletalMeshComponent* InSkeletalMeshComponent)
 {
 	this->Component = InSkeletalMeshComponent;
 }
@@ -19,9 +19,9 @@ TArray<FBoneInfo> FBoneSensor::GetBonesInfo()
 	TArray<FBoneInfo> BonesInfo;
 
 	const TArray<FBoneIndexType>& RequiredBones = Component->RequiredBones;
-	USkeletalMesh* SkeletalMesh = Component->SkeletalMesh;
+	const USkeletalMesh* SkeletalMesh = Component->GetSkeletalMeshAsset();
 	const FTransformArrayA2& ComponentSpaceTransforms = Component->GetComponentSpaceTransforms();
-	const FTransformArrayA2& BoneSpaceTransforms = Component->BoneSpaceTransforms;
+	const TArray<FTransform> BoneSpaceTransforms = Component->GetBoneSpaceTransforms();
 	const FTransform& ComponentToWorld = Component->GetComponentToWorld();
 
 	bool bIncludeAll = false;
@@ -33,7 +33,7 @@ TArray<FBoneInfo> FBoneSensor::GetBonesInfo()
 	for (int32 Index = 0; Index < RequiredBones.Num(); ++Index)
 	{
 		int32 BoneIndex = RequiredBones[Index];
-		FName BoneName = SkeletalMesh->RefSkeleton.GetBoneName(BoneIndex);
+		FName BoneName = SkeletalMesh->GetRefSkeleton().GetBoneName(BoneIndex);
 		if (!bIncludeAll
 		&& !IncludedBoneNames.Contains(BoneName.ToString()))
 		{
@@ -42,9 +42,9 @@ TArray<FBoneInfo> FBoneSensor::GetBonesInfo()
 
 		// Skip if the bone is not what we need
 
-		FTransform BoneTM = BoneSpaceTransforms[BoneIndex];
-		FTransform ComponentTM = ComponentSpaceTransforms[BoneIndex];
-		FTransform WorldTM = ComponentTM * ComponentToWorld;
+		const FTransform BoneTM = BoneSpaceTransforms[BoneIndex];
+		const FTransform ComponentTM = ComponentSpaceTransforms[BoneIndex];
+		const FTransform WorldTM = ComponentTM * ComponentToWorld;
 
 		/*
 		int32 ParentIndex = SkeletalMesh->RefSkeleton.GetParentIndex(BoneIndex);

--- a/Source/UnrealCV/Private/Sensor/CameraSensor/AnnotationCamSensor.cpp
+++ b/Source/UnrealCV/Private/Sensor/CameraSensor/AnnotationCamSensor.cpp
@@ -70,7 +70,7 @@ void UAnnotationCamSensor::GetAnnotationComponents(UWorld* World, TArray<TWeakOb
 	TArray<UObject*> UObjectList;
 	bool bIncludeDerivedClasses = false;
 	EObjectFlags ExclusionFlags = EObjectFlags::RF_ClassDefaultObject;
-	EInternalObjectFlags ExclusionInternalFlags = EInternalObjectFlags::AllFlags;
+	EInternalObjectFlags ExclusionInternalFlags = EInternalObjectFlags_AllFlags;
 	GetObjectsOfClass(UAnnotationComponent::StaticClass(), UObjectList, bIncludeDerivedClasses, ExclusionFlags, ExclusionInternalFlags);
 
 	for (UObject* Object : UObjectList)

--- a/Source/UnrealCV/Private/Sensor/CameraSensor/BaseCameraSensor.cpp
+++ b/Source/UnrealCV/Private/Sensor/CameraSensor/BaseCameraSensor.cpp
@@ -116,8 +116,7 @@ void UBaseCameraSensor::Capture(TArray<FColor>& ImageData, int& Width, int& Heig
 	if (!CheckTextureTarget()) return;
 	this->CaptureScene();
 
-	UTextureRenderTarget2D* RenderTarget = this->TextureTarget;
-	ReadTextureRenderTarget(RenderTarget, ImageData, Width, Height);
+	ReadTextureRenderTarget(TextureTarget, ImageData, Width, Height);
 }
 
 void UBaseCameraSensor::SetPostProcessMaterial(UMaterial* PostProcessMaterial)

--- a/Source/UnrealCV/Private/Server/UnrealcvServer.cpp
+++ b/Source/UnrealCV/Private/Server/UnrealcvServer.cpp
@@ -127,18 +127,22 @@ UWorld* FUnrealcvServer::GetWorld()
 		{
 			WorldPtr = EditorEngine->GetEditorWorldContext().World();
 		}
-	} // else game mode in editor
-#else
-	UGameEngine* GameEngine = Cast<UGameEngine>(GEngine);
-	if (IsValid(GameEngine))
-	{
-		WorldPtr = GameEngine->GetGameWorld(); // Not GetWorld !
-	}
-	else
-	{
-		UE_LOG(LogUnrealCV, Error, TEXT("GameEngine is invalid"));
-	}
+	} // else standalone game mode in editor
 #endif
+
+	if (!IsValid(WorldPtr))
+	{
+		UGameEngine* GameEngine = Cast<UGameEngine>(GEngine);
+		if (IsValid(GameEngine))
+		{
+			WorldPtr = GameEngine->GetGameWorld(); // Not GetWorld !
+		}
+		else
+		{
+			UE_LOG(LogUnrealCV, Error, TEXT("GameEngine is invalid"));
+		}
+
+	}
 
 	if (IsValid(WorldPtr))
 	{

--- a/Source/UnrealCV/Public/BPFunctionLib/VisionBPLib.h
+++ b/Source/UnrealCV/Public/BPFunctionLib/VisionBPLib.h
@@ -64,7 +64,7 @@ public:
 	// Extract SkeletalMesh bone information
 	UFUNCTION(BlueprintPure, Category = "unrealcv")
 	static void GetBoneTransform(
-		const USkeletalMeshComponent* SkeletalMeshComponent,
+		USkeletalMeshComponent* SkeletalMeshComponent,
 		const TArray<FString>& IncludedBones,
 		TArray<FString>& BoneNames,
 		TArray<FTransform>& BoneTransforms,
@@ -73,7 +73,7 @@ public:
 	// Get bone transformation and return as JsonObject array, this can make BP programming much easier
 	UFUNCTION(BlueprintPure, Category = "unrealcv")
 	static void GetBoneTransformJson(
-		const USkeletalMeshComponent* SkeletalMeshComponent,
+		USkeletalMeshComponent* SkeletalMeshComponent,
 		const TArray<FString>& IncludedBones,
 		TArray<FString>& BoneNames,
 		TArray<FJsonObjectBP>& BoneTransformsJson,

--- a/Source/UnrealCV/Public/Component/KeypointComponent.h
+++ b/Source/UnrealCV/Public/Component/KeypointComponent.h
@@ -33,7 +33,7 @@ struct FKeypoint
 };
 
 UCLASS(meta = (BlueprintSpawnableComponent))
-class UKeypointComponent : public USceneComponent
+class UNREALCV_API UKeypointComponent : public USceneComponent
 {
 	GENERATED_BODY()
 

--- a/Source/UnrealCV/Public/Controller/ActorController.h
+++ b/Source/UnrealCV/Public/Controller/ActorController.h
@@ -3,7 +3,7 @@
 
 #include "Runtime/Engine/Classes/GameFramework/Actor.h"
 
-class FActorController
+class UNREALCV_API FActorController
 {
 public:
 	FActorController(AActor* InActor);

--- a/Source/UnrealCV/Public/Sensor/BoneSensor.h
+++ b/Source/UnrealCV/Public/Sensor/BoneSensor.h
@@ -26,7 +26,7 @@ class UNREALCV_API FBoneSensor
 {
 public:
 	/** Construct a BoneSensor to extract data from a SkeletalMeshComponent */
-	FBoneSensor(const class USkeletalMeshComponent* InSkeletalMeshComponent);
+	explicit FBoneSensor(USkeletalMeshComponent* InSkeletalMeshComponent);
 
 	/** The bone names this BoneSensor should extract */
 	void SetBones(const TArray<FString>& InIncludedBoneNames);
@@ -38,5 +38,5 @@ public:
 	TArray<FString> IncludedBoneNames;
 
 private:
-	const USkeletalMeshComponent* Component;
+	USkeletalMeshComponent* Component;
 };

--- a/Source/UnrealCV/Public/Sensor/CameraSensor/AnnotationCamSensor.h
+++ b/Source/UnrealCV/Public/Sensor/CameraSensor/AnnotationCamSensor.h
@@ -6,7 +6,7 @@
 
 /** Annotation sensor, utilize the UAnnnotationComponent */
 UCLASS(meta = (BlueprintSpawnableComponent))
-class UAnnotationCamSensor : public UBaseCameraSensor
+class UNREALCV_API UAnnotationCamSensor : public UBaseCameraSensor
 {
 	GENERATED_BODY()
 

--- a/Source/UnrealCV/Public/Sensor/CameraSensor/DepthCamSensor.h
+++ b/Source/UnrealCV/Public/Sensor/CameraSensor/DepthCamSensor.h
@@ -6,7 +6,7 @@
 
 /** Depth sensor */
 UCLASS(meta = (BlueprintSpawnableComponent))
-class UDepthCamSensor : public UBaseCameraSensor
+class UNREALCV_API UDepthCamSensor : public UBaseCameraSensor
 {
 	GENERATED_BODY()
 

--- a/Source/UnrealCV/Public/Sensor/CameraSensor/LitCamSensor.h
+++ b/Source/UnrealCV/Public/Sensor/CameraSensor/LitCamSensor.h
@@ -10,7 +10,7 @@
  * https://forums.unrealengine.com/development-discussion/rendering/59403-scenecapturecomponent2d-antialiasing
  */
 UCLASS(meta = (BlueprintSpawnableComponent))
-class ULitCamSensor : public UBaseCameraSensor
+class UNREALCV_API ULitCamSensor : public UBaseCameraSensor
 {
 	GENERATED_BODY()
 

--- a/Source/UnrealCV/Public/Sensor/CameraSensor/NormalCamSensor.h
+++ b/Source/UnrealCV/Public/Sensor/CameraSensor/NormalCamSensor.h
@@ -6,7 +6,7 @@
 
 /** Surface normal sensor */
 UCLASS()
-class UNormalCamSensor : public UBaseCameraSensor
+class UNREALCV_API UNormalCamSensor : public UBaseCameraSensor
 {
 	GENERATED_BODY()
 

--- a/Source/UnrealCV/Public/Sensor/ImageWorker.h
+++ b/Source/UnrealCV/Public/Sensor/ImageWorker.h
@@ -16,7 +16,7 @@ struct FFrameData
 };
 
 /** Use a seperate thread to write image to files */
-class FImageWorker : public FRunnable
+class UNREALCV_API FImageWorker : public FRunnable
 {
 public:
 	FImageWorker();

--- a/Source/UnrealCV/Public/Server/ExecStatus.h
+++ b/Source/UnrealCV/Public/Server/ExecStatus.h
@@ -8,7 +8,7 @@ DECLARE_DELEGATE_RetVal(FExecStatus, FPromiseDelegate); // Check task status
 /**
  * Return by async task, used to check status to see whether the task is finished.
  */
-class FPromise
+class UNREALCV_API FPromise
 {
 private:
 	/** The method to check whether this promise is alreay completed */


### PR DESCRIPTION
* All deprecation warnings resolved
* Fixes an assertion crash when running Standalone Window from the Editor
* Export classes that do not have the `UNREALCV_API` keyword on them.

This might also compile on 5.2 but I haven't tried.