### PR TITLE
Resolve the problem of positioning unreal engine's pid in mac terminal and change the return of RunUnreal.start().

### DIFF
--- a/client/python/unrealcv/launcher.py
+++ b/client/python/unrealcv/launcher.py
@@ -100,7 +100,7 @@ class RunUnreal():
             'Please load env binary in UnrealEnv and Check the env_bin in setting file!'
 
     def start(self, docker=False, resolution=(640, 480), display=None, opengl=False, offscreen=False,
-              nullrhi=False, gpu_id=None, local_host=True, sleep_time=8):
+              nullrhi=False, gpu_id=None, local_host=True, sleep_time=8, log_file_path=None):
         """
         Start the Unreal Engine environment.
 
@@ -144,7 +144,12 @@ class RunUnreal():
             cmd_exe = [os.path.abspath(self.path2binary)]
             self.set_ue_options(cmd_exe, opengl, offscreen, nullrhi, gpu_id)
             if 'darwin' in sys.platform:
-                self.env = subprocess.Popen(['open', cmd_exe[0]])
+                if log_file_path is not None:
+                    # redirect the output to log file
+                    with open(log_file_path, "w") as log_file:
+                        self.env = subprocess.Popen(cmd_exe, stdout=log_file, stderr=log_file)
+                else:
+                    self.env = subprocess.Popen(cmd_exe, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             else:
                 self.env = subprocess.Popen( cmd_exe, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
                                             stderr=subprocess.DEVNULL, start_new_session=True, env=display)
@@ -155,7 +160,13 @@ class RunUnreal():
 
         print('Please wait for a while to launch env......')
         time.sleep(sleep_time)
-        return env_ip, port
+        launch_info = {
+            'ip': env_ip,
+            'port': port,
+            'pid': self.env.pid if not self.use_docker else None,
+            'use_docker': self.use_docker
+        }
+        return launch_info
 
     def set_ue_options(self, cmd_exe=[], opengl=False, offscreen=False, nullrhi=False, gpu_id=None):
         """


### PR DESCRIPTION
<img width="792" height="189" alt="image" src="https://github.com/user-attachments/assets/68830314-f9d0-4d2e-bcd6-26969c05dc45" />
   The return of the start function has changed, and a modification is needed in base_env.py:
launch_ue_env:
<img width="1120" height="265" alt="image" src="https://github.com/user-attachments/assets/23737418-3806-4f47-abca-648bb96d9d59" />
reset:
<img width="710" height="406" alt="image" src="https://github.com/user-attachments/assets/1d5bcfc9-6bf4-402d-9726-44547566aa1f" />
