### PR TITLE
Add editor commands to get and set object materials

### DIFF
--- a/Source/UnrealCV/Private/Commands/ObjectHandler.cpp
+++ b/Source/UnrealCV/Private/Commands/ObjectHandler.cpp
@@ -15,6 +15,10 @@
 #include "CommandInterface.h"
 #include "UnrealcvLog.h"
 
+#include "Materials/MaterialInterface.h"
+#include "Runtime/Engine/Classes/Components/MeshComponent.h"
+#include "Runtime/Engine/Classes/Components/StaticMeshComponent.h"
+
 namespace {
 
 FExecStatus SetActorName(AActor* Actor, const FString& NewName)
@@ -162,6 +166,19 @@ void FObjectHandler::RegisterCommands()
 		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetActorLabel),
 		"Set actor label"
 	);
+
+	// Get the material(s) of an object and change it (first StaticMeshComponent).
+	CommandDispatcher->BindCommand(
+		"vget /object/[str]/material",
+		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetMaterial),
+		"Get the material(s) of the object"
+	);
+
+	CommandDispatcher->BindCommand(
+		"vset /object/[str]/material [uint] [str]",
+		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetMaterial),
+		"Set material of the object (via slot index)"
+	);
 #endif
 
 	CommandDispatcher->BindCommand(
@@ -191,6 +208,23 @@ AActor* GetActor(const TArray<FString>& Args)
 	const FString& ActorId = Args[0];
 	return GetActorById(FUnrealcvServer::Get().GetWorld(), ActorId);
 }
+
+#if WITH_EDITOR
+UStaticMeshComponent* GetFirstStaticMeshComponent(AActor* Actor)
+{
+	if (!IsValid(Actor)) { return nullptr; }
+	TArray<UMeshComponent*> MeshComponents;
+	Actor->GetComponents<UMeshComponent>(MeshComponents);
+	for (UMeshComponent* MeshComponent : MeshComponents)
+	{
+		if (UStaticMeshComponent* StaticMesh = Cast<UStaticMeshComponent>(MeshComponent))
+		{
+			return StaticMesh;
+		}
+	}
+	return nullptr;
+}
+#endif
 
 } // anonymous namespace
 
@@ -490,6 +524,77 @@ FExecStatus FObjectHandler::GetActorLabel(const TArray<FString>& Args)
 
 	FString ActorLabel = Actor->GetActorLabel();
 	return FExecStatus::OK(ActorLabel);
+}
+
+FExecStatus FObjectHandler::GetMaterial(const TArray<FString>& Args)
+{
+	AActor* TargetActor = GetActor(Args);
+	if (!IsValid(TargetActor))
+	{
+		return FExecStatus::Error(TEXT("Can not find object"));
+	}
+
+	UStaticMeshComponent* MeshComponent = GetFirstStaticMeshComponent(TargetActor);
+	if (!MeshComponent)
+	{
+		return FExecStatus::Error(TEXT("Object has no StaticMeshComponent"));
+	}
+
+	FString MaterialInfo;
+
+	for (int32 SlotIndex = 0; SlotIndex < MeshComponent->GetNumMaterials(); ++SlotIndex)
+	{
+		if (UMaterialInterface* Material = MeshComponent->GetMaterial(SlotIndex))
+		{
+			MaterialInfo += FString::Printf(
+				TEXT("[%d] %s "),
+				SlotIndex,
+				*Material->GetPathName()
+			);
+		}
+	}
+
+	return FExecStatus::OK(MaterialInfo);
+}
+
+FExecStatus FObjectHandler::SetMaterial(const TArray<FString>& Args)
+{
+	if (Args.Num() != 3)
+	{
+		return FExecStatus::InvalidArgument;
+	}
+
+	AActor* TargetActor = GetActor(Args);
+	if (!IsValid(TargetActor))
+	{
+		return FExecStatus::Error(TEXT("Can not find object"));
+	}
+
+	const int32 SlotIndex = FCString::Atoi(*Args[1]);
+	const FString& MaterialPath = Args[2];
+
+	UStaticMeshComponent* MeshComponent = GetFirstStaticMeshComponent(TargetActor);
+	if (!MeshComponent)
+	{
+		return FExecStatus::Error(TEXT("Object has no StaticMeshComponent"));
+	}
+
+	if (SlotIndex < 0 || SlotIndex >= MeshComponent->GetNumMaterials())
+	{
+		return FExecStatus::Error(TEXT("Invalid material slot"));
+	}
+
+	UMaterialInterface* NewMaterial = Cast<UMaterialInterface>(
+		StaticLoadObject(UMaterialInterface::StaticClass(), nullptr, *MaterialPath)
+	);
+
+	if (!NewMaterial)
+	{
+		return FExecStatus::Error(TEXT("Can not load material"));
+	}
+
+	MeshComponent->SetMaterial(SlotIndex, NewMaterial);
+	return FExecStatus::OK();
 }
 #endif
 

--- a/Source/UnrealCV/Private/Commands/ObjectHandler.h
+++ b/Source/UnrealCV/Private/Commands/ObjectHandler.h
@@ -37,6 +37,10 @@ private:
 #if WITH_EDITOR
 	FExecStatus SetActorLabel(const TArray<FString>& Args);
 	FExecStatus GetActorLabel(const TArray<FString>& Args);
+
+	// Francisco Material commands
+	FExecStatus GetMaterial(const TArray<FString>& Args);
+	FExecStatus SetMaterial(const TArray<FString>& Args);
 #endif
 
 	FExecStatus GetScale(const TArray<FString>& Args);

--- a/docs/reference/command_schema.json
+++ b/docs/reference/command_schema.json
@@ -202,6 +202,12 @@
       "line": 77
     },
     {
+      "command": "vget /object/[str]/material",
+      "category": "object",
+      "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
+      "line": 172
+    },
+    {
       "command": "vget /object/[str]/mobility",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
@@ -506,6 +512,12 @@
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
       "line": 83
+    },
+    {
+      "command": "vset /object/[str]/material [uint] [str]",
+      "category": "object",
+      "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
+      "line": 178
     },
     {
       "command": "vset /object/[str]/name [str]",

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -120,6 +120,12 @@ vset /object/[obj_name]/hide
 vget /object/[obj_name]/mobility
     (v0.3.10) Get object mobility
 
+vget /object/[obj_name]/material
+    (editor) List material path for each slot on the first StaticMeshComponent on the object
+
+vset /object/[obj_name]/material [slot] [material_path]
+    (editor) Assign ``material_path`` to ``slot`` on the first StaticMeshComponent (UE object path, e.g. ``/Game/Materials/M_Material.M_Material``)
+
 vset /objects/spawn [class_name] [obj_name]
     (v0.4.0) Spawn an object with class name and object name. It can also be used to create a new camera, for example:
 


### PR DESCRIPTION
## Summary

Adds two **UnrealCV text commands** on the **`/object/.../material`** path so clients can **read** material slots on an object and **write** a material to a slot by **UE object path**. Applies to the **first `UStaticMeshComponent`** on the actor. Registered only when the plugin is built with **`WITH_EDITOR`** (typical **Unreal Editor** workflow).

## What changed

**Code**

- **`ObjectHandler.h` / `ObjectHandler.cpp`** — Handlers and registration for the new commands.

**Docs**

- **`docs/reference/commands.rst`**, **`docs/reference/command_schema.json`** — Document the new URIs.

**New commands (exact forms)**

| Command | What it does |
|--------|----------------|
| **`vget /object/[str]/material`** | Returns one line of text listing each **non-empty** material slot on the first static mesh: **`[slot_index] /full/path/to/asset `** (pattern repeats per slot). `[str]` is the **object/actor name** as used elsewhere (`vget /object/...`). |
| **`vset /object/[str]/material [uint] [str]`** | Sets material on **slot index** `[uint]` to the asset at **`[str]`** (full UE path, e.g. **`/Game/Folder/M_Mat.M_Mat`**). Arguments after the URI are: **`0`** = object name (from the path), **`1`** = slot, **`2`** = material path. |

**How to call them (fill in real values)**

```text
vget /object/MyActorName/material
vset /object/MyActorName/material 0 /Game/RoboVision/Materials/Glass.Glass
```

**Python (same strings, `request` sends them to the game)**

```python
client.request("vget /object/MyActorName/material")
client.request("vset /object/MyActorName/material 0 /Game/RoboVision/Materials/Glass.Glass")
```

---

## Why

Fills a gap next to other object automation: you can **script material changes** (randomization, scene setup) without doing it only in the editor UI.

---

## Notes / limits

- **No static mesh** on that actor → error response from the handler.  
- **Not** for skeletal-only meshes in this PR (first **static** mesh only).  
- **Shipping game build without editor** → these commands are **not** registered.