### PR TITLE
FIXED EXCEPTION_ACCESS_VIOLATION

### DIFF
--- a/Source/UnrealCV/Private/Controller/WorldController.cpp
+++ b/Source/UnrealCV/Private/Controller/WorldController.cpp
@@ -89,10 +89,9 @@ void AUnrealcvWorldController::BeginPlay()
 void AUnrealcvWorldController::OpenLevel(FName LevelName)
 {
 	UWorld* World = GetWorld();
-	if (!World) return;
+	if (!IsValid(World)) return;
 
 	UGameplayStatics::OpenLevel(World, LevelName);
-	UGameplayStatics::FlushLevelStreaming(World);
 	UE_LOG(LogUnrealCV, Warning, TEXT("Level loaded"));
 }
 


### PR DESCRIPTION
Fix EXCEPTION_ACCESS_VIOLATION in AUnrealcvWorldController::OpenLevel OpenLevel() was calling UGameplayStatics::FlushLevelStreaming(World) immediately after UGameplayStatics::OpenLevel(World, LevelName). But OpenLevel() begins a level travel that tears down the current world, including this actor, so the following FlushLevelStreaming call was dereferencing a world that was already mid-destruction, causing a null/near-null pointer read. Removed the FlushLevelStreaming call; nothing should touch World or this after OpenLevel() is invoked.