### PR TITLE
Add bone queries and positioned object spawning

### DIFF
--- a/.github/workflows/python-api-stability.yml
+++ b/.github/workflows/python-api-stability.yml
@@ -29,4 +29,4 @@ jobs:
         run: python client/python/tools/update_public_api_snapshot.py --repo-root . --check
 
       - name: Run API compatibility test
-        run: pytest test/client/test_public_api_snapshot.py
+        run: pytest --noconftest test/client/test_public_api_snapshot.py

--- a/Source/UnrealCV/Private/Commands/ObjectHandler.cpp
+++ b/Source/UnrealCV/Private/Commands/ObjectHandler.cpp
@@ -14,215 +14,272 @@
 #include "CubeActor.h"
 #include "CommandInterface.h"
 #include "UnrealcvLog.h"
+#include "BPFunctionLib/JsonObjectBP.h"
+#include "BPFunctionLib/SerializeBPLib.h"
 
+#include "Components/PoseableMeshComponent.h"
+#include "Components/SkeletalMeshComponent.h"
 #include "Materials/MaterialInterface.h"
 #include "Runtime/Engine/Classes/Components/MeshComponent.h"
 #include "Runtime/Engine/Classes/Components/StaticMeshComponent.h"
 
-namespace {
+namespace
+{
 
 FExecStatus SetActorName(AActor* Actor, const FString& NewName)
 {
-	UObject* ExistingObject = FindFirstObjectSafe<UObject>(*NewName);
-	if (IsValid(ExistingObject))
-	{
-		if (ExistingObject == Actor)
-		{
-			return FExecStatus::OK(TEXT("The name has already been set"));
-		}
-		// IsValid succeeded so ExistingObject is guaranteed non-null.
-		return FExecStatus::Error(FString::Printf(
-			TEXT("Renaming an object to overwrite an existing object is not allowed: %s"), *NewName));
-	}
+    UObject* ExistingObject = FindFirstObjectSafe<UObject>(*NewName);
+    if (IsValid(ExistingObject))
+    {
+        if (ExistingObject == Actor)
+        {
+            return FExecStatus::OK(TEXT("The name has already been set"));
+        }
+        // IsValid succeeded so ExistingObject is guaranteed non-null.
+        return FExecStatus::Error(
+            FString::Printf(TEXT("Renaming an object to overwrite an existing object is not allowed: %s"), *NewName));
+    }
 
-	ICommandInterface* CmdActor = Cast<ICommandInterface>(Actor);
-	if (CmdActor) { CmdActor->UnbindCommands(); }
-	Actor->Rename(*NewName);
-	if (CmdActor) { CmdActor->BindCommands(); }
-	return FExecStatus::OK();
+    ICommandInterface* CmdActor = Cast<ICommandInterface>(Actor);
+    if (CmdActor)
+    {
+        CmdActor->UnbindCommands();
+    }
+    Actor->Rename(*NewName);
+    if (CmdActor)
+    {
+        CmdActor->BindCommands();
+    }
+    return FExecStatus::OK();
+}
+
+bool TryParseVector3(const FString& XArg, const FString& YArg, const FString& ZArg, FVector& OutVector)
+{
+    float X = 0.0f;
+    float Y = 0.0f;
+    float Z = 0.0f;
+    if (!LexTryParseString(X, *XArg) || !LexTryParseString(Y, *YArg) || !LexTryParseString(Z, *ZArg))
+    {
+        return false;
+    }
+
+    OutVector = FVector(X, Y, Z);
+    return true;
+}
+
+bool ParseOptionalSpawnNameAndLocation(const TArray<FString>& Args, int32 RequiredArgCount, FString& OutName,
+                                       FVector& OutLocation, bool& bOutHasLocation)
+{
+    OutName.Reset();
+    OutLocation = FVector::ZeroVector;
+    bOutHasLocation = false;
+
+    const int32 TrailingArgCount = Args.Num() - RequiredArgCount;
+    if (TrailingArgCount == 0)
+    {
+        return true;
+    }
+    if (TrailingArgCount == 1)
+    {
+        OutName = Args[RequiredArgCount];
+        return true;
+    }
+    if (TrailingArgCount == 3)
+    {
+        bOutHasLocation = TryParseVector3(Args[RequiredArgCount], Args[RequiredArgCount + 1],
+                                          Args[RequiredArgCount + 2], OutLocation);
+        return bOutHasLocation;
+    }
+    if (TrailingArgCount == 4)
+    {
+        OutName = Args[RequiredArgCount];
+        bOutHasLocation = TryParseVector3(Args[RequiredArgCount + 1], Args[RequiredArgCount + 2],
+                                          Args[RequiredArgCount + 3], OutLocation);
+        return bOutHasLocation;
+    }
+    return false;
+}
+
+TArray<FName> ParseBoneNamesCsv(const FString& Csv)
+{
+    TArray<FString> BoneTokens;
+    Csv.ParseIntoArray(BoneTokens, TEXT(","), true);
+
+    TArray<FName> BoneNames;
+    for (FString& BoneToken : BoneTokens)
+    {
+        BoneToken.TrimStartAndEndInline();
+        if (!BoneToken.IsEmpty())
+        {
+            BoneNames.Add(FName(*BoneToken));
+        }
+    }
+    return BoneNames;
 }
 
 } // anonymous namespace
 
 void FObjectHandler::RegisterCommands()
 {
-	CommandDispatcher->BindCommand(
-		"vget /objects",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetObjectList),
-		"Get the name of all objects"
-	);
+    CommandDispatcher->BindCommand("vget /objects",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetObjectList),
+                                   "Get the name of all objects");
 
-	CommandDispatcher->BindCommand(
-		"vset /objects/spawn_cube",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SpawnBox),
-		"Spawn a box in the scene for debugging purpose."
-	);
+    CommandDispatcher->BindCommand("vset /objects/spawn_cube",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SpawnBox),
+                                   "Spawn a box in the scene for debugging purpose.");
 
-	CommandDispatcher->BindCommand(
-		"vset /objects/spawn_cube [str]",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SpawnBox),
-		"Spawn a box in the scene for debugging purpose, with optional argument name."
-	);
+    CommandDispatcher->BindCommand("vset /objects/spawn_cube [str]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SpawnBox),
+                                   "Spawn a box in the scene for debugging purpose, with optional argument name.");
 
-	CommandDispatcher->BindCommand(
-		"vset /objects/spawn [str]",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::Spawn),
-		"Spawn an object with UClassName as the argument."
-	);
+    CommandDispatcher->BindCommand("vset /objects/spawn_cube [float] [float] [float]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SpawnBox),
+                                   "Spawn a box at world location [x, y, z].");
 
-	CommandDispatcher->BindCommand(
-		"vset /objects/spawn [str] [str]",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::Spawn),
-		"Spawn an object with UClassName as the argument."
-	);
+    CommandDispatcher->BindCommand("vset /objects/spawn_cube [str] [float] [float] [float]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SpawnBox),
+                                   "Spawn a named box at world location [x, y, z].");
 
-	CommandDispatcher->BindCommand(
-		"vget /object/[str]/location",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetLocation),
-		"Get object location [x, y, z]"
-	);
+    CommandDispatcher->BindCommand("vset /objects/spawn [str]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::Spawn),
+                                   "Spawn an object with UClassName as the argument.");
 
-	CommandDispatcher->BindCommand(
-		"vset /object/[str]/location [float] [float] [float]",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetLocation),
-		"Set object location [x, y, z]"
-	);
+    CommandDispatcher->BindCommand("vset /objects/spawn [str] [str]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::Spawn),
+                                   "Spawn an object with UClassName as the argument.");
 
-	CommandDispatcher->BindCommand(
-		"vget /object/[str]/rotation",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetRotation),
-		"Get object rotation [pitch, yaw, roll]"
-	);
+    CommandDispatcher->BindCommand("vset /objects/spawn [str] [float] [float] [float]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::Spawn),
+                                   "Spawn an object at world location [x, y, z].");
 
-	CommandDispatcher->BindCommand(
-		"vset /object/[str]/rotation [float] [float] [float]",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetRotation),
-		"Set object rotation [pitch, yaw, roll]"
-	);
+    CommandDispatcher->BindCommand("vset /objects/spawn [str] [str] [float] [float] [float]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::Spawn),
+                                   "Spawn a named object at world location [x, y, z].");
 
-	CommandDispatcher->BindCommand(
-		"vget /object/[str]/vertex_location",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetObjectVertexLocation),
-		"Get vertex location"
-	);
+    CommandDispatcher->BindCommand("vget /object/[str]/location",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetLocation),
+                                   "Get object location [x, y, z]");
 
-	CommandDispatcher->BindCommand(
-		"vget /object/[str]/color",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetAnnotationColor),
-		"Get the labeling color of an object (used in object instance mask)"
-	);
+    CommandDispatcher->BindCommand("vset /object/[str]/location [float] [float] [float]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetLocation),
+                                   "Set object location [x, y, z]");
 
-	CommandDispatcher->BindCommand(
-		"vset /object/[str]/color [uint] [uint] [uint]",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetAnnotationColor),
-		"Set the labeling color of an object [r, g, b]"
-	);
+    CommandDispatcher->BindCommand("vget /object/[str]/rotation",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetRotation),
+                                   "Get object rotation [pitch, yaw, roll]");
 
-	CommandDispatcher->BindCommand(
-		"vget /object/[str]/mobility",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetMobility),
-		"Is the object static or movable?"
-	);
+    CommandDispatcher->BindCommand("vset /object/[str]/rotation [float] [float] [float]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetRotation),
+                                   "Set object rotation [pitch, yaw, roll]");
 
-	CommandDispatcher->BindCommand(
-		"vset /object/[str]/show",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetShow),
-		"Show object"
-	);
+    CommandDispatcher->BindCommand("vget /object/[str]/vertex_location",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetObjectVertexLocation),
+                                   "Get vertex location");
 
-	CommandDispatcher->BindCommand(
-		"vset /object/[str]/hide",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetHide),
-		"Hide object"
-	);
+    CommandDispatcher->BindCommand("vget /object/[str]/color",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetAnnotationColor),
+                                   "Get the labeling color of an object (used in object instance mask)");
 
-	CommandDispatcher->BindCommand(
-		"vset /object/[str]/destroy",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::Destroy),
-		"Destroy object"
-	);
+    CommandDispatcher->BindCommand("vset /object/[str]/color [uint] [uint] [uint]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetAnnotationColor),
+                                   "Set the labeling color of an object [r, g, b]");
 
-	CommandDispatcher->BindCommand(
-		"vget /object/[str]/uclass_name",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetUClassName),
-		"Get the UClass name for filtering objects"
-	);
+    CommandDispatcher->BindCommand("vget /object/[str]/mobility",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetMobility),
+                                   "Is the object static or movable?");
 
-	CommandDispatcher->BindCommand(
-		"vset /object/[str]/name [str]",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetName),
-		"Set the name of the object"
-	);
+    CommandDispatcher->BindCommand("vset /object/[str]/show",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetShow), "Show object");
+
+    CommandDispatcher->BindCommand("vset /object/[str]/hide",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetHide), "Hide object");
+
+    CommandDispatcher->BindCommand("vset /object/[str]/destroy",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::Destroy), "Destroy object");
+
+    CommandDispatcher->BindCommand("vget /object/[str]/uclass_name",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetUClassName),
+                                   "Get the UClass name for filtering objects");
+
+    CommandDispatcher->BindCommand("vset /object/[str]/name [str]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetName),
+                                   "Set the name of the object");
 
 #if WITH_EDITOR
-	CommandDispatcher->BindCommand(
-		"vget /object/[str]/label",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetActorLabel),
-		"Get actor label"
-	);
+    CommandDispatcher->BindCommand("vget /object/[str]/label",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetActorLabel),
+                                   "Get actor label");
 
-	CommandDispatcher->BindCommand(
-		"vset /object/[str]/label [str]",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetActorLabel),
-		"Set actor label"
-	);
+    CommandDispatcher->BindCommand("vset /object/[str]/label [str]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetActorLabel),
+                                   "Set actor label");
 
-	// Get the material(s) of an object and change it (first StaticMeshComponent).
-	CommandDispatcher->BindCommand(
-		"vget /object/[str]/material",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetMaterial),
-		"Get the material(s) of the object"
-	);
+    // Get the material(s) of an object and change it (first StaticMeshComponent).
+    CommandDispatcher->BindCommand("vget /object/[str]/material",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetMaterial),
+                                   "Get the material(s) of the object");
 
-	CommandDispatcher->BindCommand(
-		"vset /object/[str]/material [uint] [str]",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetMaterial),
-		"Set material of the object (via slot index)"
-	);
+    CommandDispatcher->BindCommand("vset /object/[str]/material [uint] [str]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetMaterial),
+                                   "Set material of the object (via slot index)");
 #endif
 
-	CommandDispatcher->BindCommand(
-		"vget /object/[str]/scale",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetScale),
-		"Get object rotation [x, y, z]"
-	);
+    CommandDispatcher->BindCommand("vget /object/[str]/scale",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetScale),
+                                   "Get object rotation [x, y, z]");
 
-	CommandDispatcher->BindCommand(
-		"vset /object/[str]/scale [float] [float] [float]",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetScale),
-		"Set object scale [x, y, z]"
-	);
+    CommandDispatcher->BindCommand("vset /object/[str]/scale [float] [float] [float]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::SetScale),
+                                   "Set object scale [x, y, z]");
 
-	CommandDispatcher->BindCommand(
-		"vget /object/[str]/bounds",
-		FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetBounds),
-		"Return the bounds in the world coordinate, formate is [minx, y, z, maxx, y, z]"
-	);
+    CommandDispatcher->BindCommand("vget /object/[str]/bounds",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetBounds),
+                                   "Return the bounds in the world coordinate, formate is [minx, y, z, maxx, y, z]");
+
+    CommandDispatcher->BindCommand("vget /object/[str]/bones",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetBones),
+                                   "Get all bone transforms in component space as JSON.");
+
+    CommandDispatcher->BindCommand("vget /object/[str]/bones [str]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetBones),
+                                   "Get comma-separated bones, or all bones in component|world space, as JSON.");
+
+    CommandDispatcher->BindCommand("vget /object/[str]/bones [str] [str]",
+                                   FDispatcherDelegate::CreateRaw(this, &FObjectHandler::GetBones),
+                                   "Get comma-separated bones in component|world space as JSON.");
 }
 
-namespace {
+namespace
+{
 
 AActor* GetActor(const TArray<FString>& Args)
 {
-	if (Args.Num() < 1) { return nullptr; }
-	const FString& ActorId = Args[0];
-	return GetActorById(FUnrealcvServer::Get().GetWorld(), ActorId);
+    if (Args.Num() < 1)
+    {
+        return nullptr;
+    }
+    const FString& ActorId = Args[0];
+    return GetActorById(FUnrealcvServer::Get().GetWorld(), ActorId);
 }
 
 #if WITH_EDITOR
 UStaticMeshComponent* GetFirstStaticMeshComponent(AActor* Actor)
 {
-	if (!IsValid(Actor)) { return nullptr; }
-	TArray<UMeshComponent*> MeshComponents;
-	Actor->GetComponents<UMeshComponent>(MeshComponents);
-	for (UMeshComponent* MeshComponent : MeshComponents)
-	{
-		if (UStaticMeshComponent* StaticMesh = Cast<UStaticMeshComponent>(MeshComponent))
-		{
-			return StaticMesh;
-		}
-	}
-	return nullptr;
+    if (!IsValid(Actor))
+    {
+        return nullptr;
+    }
+    TArray<UMeshComponent*> MeshComponents;
+    Actor->GetComponents<UMeshComponent>(MeshComponents);
+    for (UMeshComponent* MeshComponent : MeshComponents)
+    {
+        if (UStaticMeshComponent* StaticMesh = Cast<UStaticMeshComponent>(MeshComponent))
+        {
+            return StaticMesh;
+        }
+    }
+    return nullptr;
 }
 #endif
 
@@ -230,413 +287,581 @@ UStaticMeshComponent* GetFirstStaticMeshComponent(AActor* Actor)
 
 FExecStatus FObjectHandler::GetObjectList(const TArray<FString>& Args)
 {
-	TArray<AActor*> ActorList;
-	UVisionBPLib::GetActorList(ActorList);
+    TArray<AActor*> ActorList;
+    UVisionBPLib::GetActorList(ActorList);
 
-	FString StrActorList;
-	for (AActor* Actor : ActorList)
-	{
-		StrActorList += FString::Printf(TEXT("%s "), *Actor->GetName());
-	}
-	return FExecStatus::OK(StrActorList);
+    FString StrActorList;
+    for (AActor* Actor : ActorList)
+    {
+        StrActorList += FString::Printf(TEXT("%s "), *Actor->GetName());
+    }
+    return FExecStatus::OK(StrActorList);
 }
 
 FExecStatus FObjectHandler::GetLocation(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	FActorController Controller(Actor);
-	FVector Location = Controller.GetLocation();
+    FActorController Controller(Actor);
+    FVector Location = Controller.GetLocation();
 
-	FStrFormatter Ar;
-	Ar << Location;
+    FStrFormatter Ar;
+    Ar << Location;
 
-	return FExecStatus::OK(Ar.ToString());
+    return FExecStatus::OK(Ar.ToString());
 }
 
 /** There is no guarantee this will always succeed, for example, hitting a wall */
 FExecStatus FObjectHandler::SetLocation(const TArray<FString>& Args)
 {
-	if (Args.Num() < 4) { return FExecStatus::InvalidArgument; }
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
-	FActorController Controller(Actor);
+    if (Args.Num() < 4)
+    {
+        return FExecStatus::InvalidArgument;
+    }
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
+    FActorController Controller(Actor);
 
-	// TODO: Check whether this object is movable
-	float X = FCString::Atof(*Args[1]), Y = FCString::Atof(*Args[2]), Z = FCString::Atof(*Args[3]);
-	FVector NewLocation = FVector(X, Y, Z);
-	Controller.SetLocation(NewLocation);
+    // TODO: Check whether this object is movable
+    float X = FCString::Atof(*Args[1]), Y = FCString::Atof(*Args[2]), Z = FCString::Atof(*Args[3]);
+    FVector NewLocation = FVector(X, Y, Z);
+    Controller.SetLocation(NewLocation);
 
-	return FExecStatus::OK();
+    return FExecStatus::OK();
 }
 
 FExecStatus FObjectHandler::GetRotation(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	FActorController Controller(Actor);
-	FRotator Rotation = Controller.GetRotation();
+    FActorController Controller(Actor);
+    FRotator Rotation = Controller.GetRotation();
 
-	FStrFormatter Ar;
-	Ar << Rotation;
+    FStrFormatter Ar;
+    Ar << Rotation;
 
-	return FExecStatus::OK(Ar.ToString());
+    return FExecStatus::OK(Ar.ToString());
 }
 
 FExecStatus FObjectHandler::SetRotation(const TArray<FString>& Args)
 {
-	if (Args.Num() < 4) { return FExecStatus::InvalidArgument; }
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
-	FActorController Controller(Actor);
+    if (Args.Num() < 4)
+    {
+        return FExecStatus::InvalidArgument;
+    }
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
+    FActorController Controller(Actor);
 
-	// TODO: Check whether this object is movable
-	float Pitch = FCString::Atof(*Args[1]), Yaw = FCString::Atof(*Args[2]), Roll = FCString::Atof(*Args[3]);
-	FRotator Rotator = FRotator(Pitch, Yaw, Roll);
-	Controller.SetRotation(Rotator);
+    // TODO: Check whether this object is movable
+    float Pitch = FCString::Atof(*Args[1]), Yaw = FCString::Atof(*Args[2]), Roll = FCString::Atof(*Args[3]);
+    FRotator Rotator = FRotator(Pitch, Yaw, Roll);
+    Controller.SetRotation(Rotator);
 
-	return FExecStatus::OK();
+    return FExecStatus::OK();
 }
-
 
 FExecStatus FObjectHandler::GetAnnotationColor(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
-	FActorController Controller(Actor);
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
+    FActorController Controller(Actor);
 
-	FColor AnnotationColor;
-	Controller.GetAnnotationColor(AnnotationColor);
-	return FExecStatus::OK(AnnotationColor.ToString());
+    FColor AnnotationColor;
+    Controller.GetAnnotationColor(AnnotationColor);
+    return FExecStatus::OK(AnnotationColor.ToString());
 }
 
 FExecStatus FObjectHandler::SetAnnotationColor(const TArray<FString>& Args)
 {
-	if (Args.Num() < 4) { return FExecStatus::InvalidArgument; }
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
-	FActorController Controller(Actor);
+    if (Args.Num() < 4)
+    {
+        return FExecStatus::InvalidArgument;
+    }
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
+    FActorController Controller(Actor);
 
-	// ObjectName, R, G, B, A = 255
-	// The color format is RGBA
-	uint32 R = FCString::Atoi(*Args[1]), G = FCString::Atoi(*Args[2]), B = FCString::Atoi(*Args[3]), A = 255; // A = FCString::Atoi(*Args[4]);
-	FColor AnnotationColor(R, G, B, A);
+    // ObjectName, R, G, B, A = 255
+    // The color format is RGBA
+    uint32 R = FCString::Atoi(*Args[1]), G = FCString::Atoi(*Args[2]), B = FCString::Atoi(*Args[3]),
+           A = 255; // A = FCString::Atoi(*Args[4]);
+    FColor AnnotationColor(R, G, B, A);
 
-	Controller.SetAnnotationColor(AnnotationColor);
-	return FExecStatus::OK();
+    Controller.SetAnnotationColor(AnnotationColor);
+    return FExecStatus::OK();
 }
 
 FExecStatus FObjectHandler::GetMobility(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
-	FActorController Controller(Actor);
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
+    FActorController Controller(Actor);
 
-	FString MobilityName = "";
-	EComponentMobility::Type Mobility = Controller.GetMobility();
-	switch (Mobility)
-	{
-		case EComponentMobility::Type::Movable: MobilityName = "Movable"; break;
-		case EComponentMobility::Type::Static: MobilityName = "Static"; break;
-		case EComponentMobility::Type::Stationary: MobilityName = "Stationary"; break;
-		default: MobilityName = "Unknown";
-	}
-	return FExecStatus::OK(MobilityName);
+    FString MobilityName = "";
+    EComponentMobility::Type Mobility = Controller.GetMobility();
+    switch (Mobility)
+    {
+    case EComponentMobility::Type::Movable:
+        MobilityName = "Movable";
+        break;
+    case EComponentMobility::Type::Static:
+        MobilityName = "Static";
+        break;
+    case EComponentMobility::Type::Stationary:
+        MobilityName = "Stationary";
+        break;
+    default:
+        MobilityName = "Unknown";
+    }
+    return FExecStatus::OK(MobilityName);
 }
 
 FExecStatus FObjectHandler::SetShow(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	FActorController Controller(Actor);
-	Controller.Show();
-	return FExecStatus::OK();
+    FActorController Controller(Actor);
+    Controller.Show();
+    return FExecStatus::OK();
 }
 
 FExecStatus FObjectHandler::SetHide(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	FActorController Controller(Actor);
-	Controller.Hide();
-	return FExecStatus::OK();
+    FActorController Controller(Actor);
+    Controller.Hide();
+    return FExecStatus::OK();
 }
 
 FExecStatus FObjectHandler::GetObjectVertexLocation(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
-	FVertexSensor VertexSensor(Actor);
-	TArray<FVector> VertexArray = VertexSensor.GetVertexArray();
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
+    FVertexSensor VertexSensor(Actor);
+    TArray<FVector> VertexArray = VertexSensor.GetVertexArray();
 
-	// Serialize it to json?
-	FString Str = "";
-	for (const auto& Vertex : VertexArray)
-	{
-		FString VertexLocation = FString::Printf(
-			TEXT("%.5f     %.5f     %.5f"),
-			Vertex.X, Vertex.Y, Vertex.Z);
-		Str += VertexLocation + "\n";
-	}
+    // Serialize it to json?
+    FString Str = "";
+    for (const auto& Vertex : VertexArray)
+    {
+        FString VertexLocation = FString::Printf(TEXT("%.5f     %.5f     %.5f"), Vertex.X, Vertex.Y, Vertex.Z);
+        Str += VertexLocation + "\n";
+    }
 
-	return FExecStatus::OK(Str);
+    return FExecStatus::OK(Str);
 }
 
 /** A debug utility function to create StaticBox through python API */
 FExecStatus FObjectHandler::SpawnBox(const TArray<FString>& Args)
 {
-	UWorld* GameWorld = FUnrealcvServer::Get().GetWorld();
-	AActor* Actor = GameWorld->SpawnActor(ACubeActor::StaticClass());
-	if (!IsValid(Actor))
-	{
-		return FExecStatus::Error(TEXT("Failed to spawn cube actor"));
-	}
-	if (Args.Num() == 1)
-	{
-		SetActorName(Actor, Args[0]);
-	}
-	return FExecStatus::OK(Actor->GetName());
+    FString ObjectName;
+    FVector SpawnLocation = FVector::ZeroVector;
+    bool bHasSpawnLocation = false;
+    if (!ParseOptionalSpawnNameAndLocation(Args, 0, ObjectName, SpawnLocation, bHasSpawnLocation))
+    {
+        return FExecStatus::InvalidArgument;
+    }
+
+    UWorld* GameWorld = FUnrealcvServer::Get().GetWorld();
+    if (!IsValid(GameWorld))
+    {
+        return FExecStatus::Error(TEXT("Cannot get world"));
+    }
+
+    FActorSpawnParameters SpawnParameters;
+    SpawnParameters.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+    AActor* Actor = GameWorld->SpawnActor<ACubeActor>(ACubeActor::StaticClass(),
+                                                      bHasSpawnLocation ? SpawnLocation : FVector::ZeroVector,
+                                                      FRotator::ZeroRotator, SpawnParameters);
+    if (!IsValid(Actor))
+    {
+        return FExecStatus::Error(TEXT("Failed to spawn cube actor"));
+    }
+    if (!ObjectName.IsEmpty())
+    {
+        const FExecStatus RenameStatus = SetActorName(Actor, ObjectName);
+        if (RenameStatus.GetStatusType() == EExecStatusType::Error)
+        {
+            Actor->Destroy();
+            return RenameStatus;
+        }
+    }
+    return FExecStatus::OK(Actor->GetName());
 }
 
 FExecStatus FObjectHandler::Spawn(const TArray<FString>& Args)
 {
-	if (Args.Num() == 2)
-	{
-		const FString& ActorId = Args[1];
-		AActor* Actor = GetActorById(FUnrealcvServer::Get().GetWorld(), ActorId);
-		if (IsValid(Actor))
-		{
-			FString ErrorMsg = FString::Printf(TEXT("Failed to spawn %s, object exists."), *ActorId);
-			UE_LOG(LogUnrealCV, Warning, TEXT("%s"), *ErrorMsg);
-			return FExecStatus::Error(ErrorMsg);
-		}
-	}
+    if (Args.Num() < 1 || Args.Num() > 5)
+    {
+        return FExecStatus::InvalidArgument;
+    }
 
-	FString UClassName;
-	if (Args.Num() == 1 || Args.Num() == 2)
-	{
-		UClassName = Args[0];
-	}
-	// Lookup UClass with a string
-	UClass*	Class = FindFirstObjectSafe<UClass>(*UClassName);
+    FString ActorName;
+    FVector SpawnLocation = FVector::ZeroVector;
+    bool bHasSpawnLocation = false;
+    if (!ParseOptionalSpawnNameAndLocation(Args, 1, ActorName, SpawnLocation, bHasSpawnLocation))
+    {
+        return FExecStatus::InvalidArgument;
+    }
 
-	if (!IsValid(Class))
-	{
-		FString ErrorMsg = FString::Printf(TEXT("Can not find a class with name '%s'"), *UClassName);
-		UE_LOG(LogUnrealCV, Warning, TEXT("%s"), *ErrorMsg);
-		return FExecStatus::Error(ErrorMsg);
-	}
+    if (!ActorName.IsEmpty())
+    {
+        AActor* Actor = GetActorById(FUnrealcvServer::Get().GetWorld(), ActorName);
+        if (IsValid(Actor))
+        {
+            FString ErrorMsg = FString::Printf(TEXT("Failed to spawn %s, object exists."), *ActorName);
+            UE_LOG(LogUnrealCV, Warning, TEXT("%s"), *ErrorMsg);
+            return FExecStatus::Error(ErrorMsg);
+        }
+    }
 
-	UWorld* GameWorld = FUnrealcvServer::Get().GetWorld();
-	FActorSpawnParameters SpawnParameters;
-	// SpawnParameters.bNoFail = true; // Allow collision during spawn.
-	SpawnParameters.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-	AActor* Actor = GameWorld->SpawnActor(Class, NULL, NULL, SpawnParameters);
-	if (!IsValid(Actor))
-	{
-		return FExecStatus::Error("Failed to spawn actor");
-	}
+    const FString& UClassName = Args[0];
+    // Lookup UClass with a string
+    UClass* Class = FindFirstObjectSafe<UClass>(*UClassName);
 
-	if (Args.Num() == 2)
-	{
-		const FString& ActorName = Args[1];
-		SetActorName(Actor, ActorName);
-	}
-	return FExecStatus::OK(Actor->GetName());
+    if (!IsValid(Class))
+    {
+        FString ErrorMsg = FString::Printf(TEXT("Can not find a class with name '%s'"), *UClassName);
+        UE_LOG(LogUnrealCV, Warning, TEXT("%s"), *ErrorMsg);
+        return FExecStatus::Error(ErrorMsg);
+    }
+
+    UWorld* GameWorld = FUnrealcvServer::Get().GetWorld();
+    if (!IsValid(GameWorld))
+    {
+        return FExecStatus::Error(TEXT("Cannot get world"));
+    }
+    FActorSpawnParameters SpawnParameters;
+    // SpawnParameters.bNoFail = true; // Allow collision during spawn.
+    SpawnParameters.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+    AActor* Actor = GameWorld->SpawnActor<AActor>(Class, bHasSpawnLocation ? SpawnLocation : FVector::ZeroVector,
+                                                  FRotator::ZeroRotator, SpawnParameters);
+    if (!IsValid(Actor))
+    {
+        return FExecStatus::Error(TEXT("Failed to spawn actor"));
+    }
+
+    if (!ActorName.IsEmpty())
+    {
+        const FExecStatus RenameStatus = SetActorName(Actor, ActorName);
+        if (RenameStatus.GetStatusType() == EExecStatusType::Error)
+        {
+            Actor->Destroy();
+            return RenameStatus;
+        }
+    }
+    return FExecStatus::OK(Actor->GetName());
+}
+
+FExecStatus FObjectHandler::GetBones(const TArray<FString>& Args)
+{
+    AActor* Actor = GetActor(Args);
+    if (!IsValid(Actor))
+    {
+        return FExecStatus::Error(TEXT("Cannot find object"));
+    }
+
+    TArray<FName> BoneNames;
+    bool bWorldSpace = false;
+    if (Args.Num() >= 2)
+    {
+        if (Args[1].Equals(TEXT("world"), ESearchCase::IgnoreCase) ||
+            Args[1].Equals(TEXT("component"), ESearchCase::IgnoreCase))
+        {
+            bWorldSpace = Args[1].Equals(TEXT("world"), ESearchCase::IgnoreCase);
+        }
+        else
+        {
+            BoneNames = ParseBoneNamesCsv(Args[1]);
+        }
+    }
+    if (Args.Num() >= 3)
+    {
+        if (!Args[2].Equals(TEXT("world"), ESearchCase::IgnoreCase) &&
+            !Args[2].Equals(TEXT("component"), ESearchCase::IgnoreCase))
+        {
+            return FExecStatus::Error(TEXT("Bone space must be component or world"));
+        }
+        bWorldSpace = Args[2].Equals(TEXT("world"), ESearchCase::IgnoreCase);
+    }
+
+    TArray<UPoseableMeshComponent*> PoseableMeshComponents;
+    Actor->GetComponents<UPoseableMeshComponent>(PoseableMeshComponents);
+    TArray<USkeletalMeshComponent*> SkeletalMeshComponents;
+    Actor->GetComponents<USkeletalMeshComponent>(SkeletalMeshComponents);
+
+    USkinnedMeshComponent* SkinnedMeshComponent = nullptr;
+    if (PoseableMeshComponents.Num() > 0 && IsValid(PoseableMeshComponents[0]))
+    {
+        SkinnedMeshComponent = PoseableMeshComponents[0];
+    }
+    else if (SkeletalMeshComponents.Num() > 0 && IsValid(SkeletalMeshComponents[0]))
+    {
+        SkinnedMeshComponent = SkeletalMeshComponents[0];
+    }
+    if (!IsValid(SkinnedMeshComponent))
+    {
+        return FExecStatus::Error(TEXT("No skeletal or poseable mesh component found"));
+    }
+
+    if (BoneNames.IsEmpty())
+    {
+        const int32 NumBones = SkinnedMeshComponent->GetNumBones();
+        BoneNames.Reserve(NumBones);
+        for (int32 BoneIndex = 0; BoneIndex < NumBones; ++BoneIndex)
+        {
+            BoneNames.Add(SkinnedMeshComponent->GetBoneName(BoneIndex));
+        }
+    }
+
+    UPoseableMeshComponent* PoseableMeshComponent = Cast<UPoseableMeshComponent>(SkinnedMeshComponent);
+    USkeletalMeshComponent* SkeletalMeshComponent = Cast<USkeletalMeshComponent>(SkinnedMeshComponent);
+    TArray<FJsonObjectBP> BoneJsonArray;
+    BoneJsonArray.Reserve(BoneNames.Num());
+    for (const FName& BoneName : BoneNames)
+    {
+        const int32 BoneIndex = SkinnedMeshComponent->GetBoneIndex(BoneName);
+        if (BoneIndex == INDEX_NONE)
+        {
+            continue;
+        }
+
+        FTransform BoneTransform = FTransform::Identity;
+        if (PoseableMeshComponent)
+        {
+            BoneTransform = PoseableMeshComponent->GetBoneTransformByName(
+                BoneName, bWorldSpace ? EBoneSpaces::WorldSpace : EBoneSpaces::ComponentSpace);
+        }
+        else if (SkeletalMeshComponent)
+        {
+            BoneTransform = SkeletalMeshComponent->GetBoneTransform(BoneIndex);
+            if (!bWorldSpace)
+            {
+                BoneTransform = BoneTransform.GetRelativeTransform(SkeletalMeshComponent->GetComponentTransform());
+            }
+        }
+
+        const TArray<FString> Keys = {TEXT("bone_name"), TEXT("transform")};
+        const TArray<FJsonObjectBP> Values = {FJsonObjectBP(BoneName.ToString()), FJsonObjectBP(BoneTransform)};
+        BoneJsonArray.Add(USerializeBPLib::TMapToJson(Keys, Values));
+    }
+
+    return FExecStatus::OK(FJsonObjectBP(BoneJsonArray).ToString());
 }
 
 FExecStatus FObjectHandler::Destroy(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	Actor->Destroy();
-	return FExecStatus::OK();
+    Actor->Destroy();
+    return FExecStatus::OK();
 }
 
 FExecStatus FObjectHandler::GetUClassName(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	FString UClassName = Actor->GetClass()->GetName();
-	return FExecStatus::OK(UClassName);
+    FString UClassName = Actor->GetClass()->GetName();
+    return FExecStatus::OK(UClassName);
 }
 
 /** Get component names of the object */
 FExecStatus FObjectHandler::GetComponents(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!IsValid(Actor)) { return FExecStatus::Error(TEXT("Cannot find object")); }
+    AActor* Actor = GetActor(Args);
+    if (!IsValid(Actor))
+    {
+        return FExecStatus::Error(TEXT("Cannot find object"));
+    }
 
-	FString Result;
-	TInlineComponentArray<UActorComponent*> Components;
-	Actor->GetComponents(Components);
-	for (const UActorComponent* Component : Components)
-	{
-		if (IsValid(Component))
-		{
-			Result += Component->GetName() + TEXT(" ");
-		}
-	}
-	return FExecStatus::OK(Result);
+    FString Result;
+    TInlineComponentArray<UActorComponent*> Components;
+    Actor->GetComponents(Components);
+    for (const UActorComponent* Component : Components)
+    {
+        if (IsValid(Component))
+        {
+            Result += Component->GetName() + TEXT(" ");
+        }
+    }
+    return FExecStatus::OK(Result);
 }
-
 
 FExecStatus FObjectHandler::SetName(const TArray<FString>& Args)
 {
-	if (Args.Num() != 2)
-	{
-		return FExecStatus::InvalidArgument;
-	}
-	AActor* Actor = GetActor(Args);
-	if (!Actor) return FExecStatus::Error(TEXT("Cannot find object"));
+    if (Args.Num() != 2)
+    {
+        return FExecStatus::InvalidArgument;
+    }
+    AActor* Actor = GetActor(Args);
+    if (!Actor)
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	const FString& NewName = Args[1];
-	// Check whether the object name already exists, otherwise it will crash in
-	// File:/home/qiuwch/UnrealEngine/Engine/Source/Runtime/CoreUObject/Private/UObject/Obj.cpp] [Line: 198]
-	FExecStatus Status = SetActorName(Actor, NewName);
+    const FString& NewName = Args[1];
+    // Check whether the object name already exists, otherwise it will crash in
+    // File:/home/qiuwch/UnrealEngine/Engine/Source/Runtime/CoreUObject/Private/UObject/Obj.cpp] [Line: 198]
+    FExecStatus Status = SetActorName(Actor, NewName);
 
-	return Status;
+    return Status;
 }
 
 #if WITH_EDITOR
 FExecStatus FObjectHandler::SetActorLabel(const TArray<FString>& Args)
 {
-	FString ActorLabel;
-	if (Args.Num() == 2) { ActorLabel = Args[1]; }
+    FString ActorLabel;
+    if (Args.Num() == 2)
+    {
+        ActorLabel = Args[1];
+    }
 
-	AActor* Actor = GetActor(Args);
-	if (!IsValid(Actor)) return FExecStatus::Error(TEXT("Cannot find object"));
+    AActor* Actor = GetActor(Args);
+    if (!IsValid(Actor))
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	Actor->SetActorLabel(ActorLabel);
-	return FExecStatus::OK();
+    Actor->SetActorLabel(ActorLabel);
+    return FExecStatus::OK();
 }
 
 FExecStatus FObjectHandler::GetActorLabel(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!IsValid(Actor)) return FExecStatus::Error(TEXT("Cannot find object"));
+    AActor* Actor = GetActor(Args);
+    if (!IsValid(Actor))
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	FString ActorLabel = Actor->GetActorLabel();
-	return FExecStatus::OK(ActorLabel);
+    FString ActorLabel = Actor->GetActorLabel();
+    return FExecStatus::OK(ActorLabel);
 }
 
 FExecStatus FObjectHandler::GetMaterial(const TArray<FString>& Args)
 {
-	AActor* TargetActor = GetActor(Args);
-	if (!IsValid(TargetActor))
-	{
-		return FExecStatus::Error(TEXT("Can not find object"));
-	}
+    AActor* TargetActor = GetActor(Args);
+    if (!IsValid(TargetActor))
+    {
+        return FExecStatus::Error(TEXT("Can not find object"));
+    }
 
-	UStaticMeshComponent* MeshComponent = GetFirstStaticMeshComponent(TargetActor);
-	if (!MeshComponent)
-	{
-		return FExecStatus::Error(TEXT("Object has no StaticMeshComponent"));
-	}
+    UStaticMeshComponent* MeshComponent = GetFirstStaticMeshComponent(TargetActor);
+    if (!MeshComponent)
+    {
+        return FExecStatus::Error(TEXT("Object has no StaticMeshComponent"));
+    }
 
-	FString MaterialInfo;
+    FString MaterialInfo;
 
-	for (int32 SlotIndex = 0; SlotIndex < MeshComponent->GetNumMaterials(); ++SlotIndex)
-	{
-		if (UMaterialInterface* Material = MeshComponent->GetMaterial(SlotIndex))
-		{
-			MaterialInfo += FString::Printf(
-				TEXT("[%d] %s "),
-				SlotIndex,
-				*Material->GetPathName()
-			);
-		}
-	}
+    for (int32 SlotIndex = 0; SlotIndex < MeshComponent->GetNumMaterials(); ++SlotIndex)
+    {
+        if (UMaterialInterface* Material = MeshComponent->GetMaterial(SlotIndex))
+        {
+            MaterialInfo += FString::Printf(TEXT("[%d] %s "), SlotIndex, *Material->GetPathName());
+        }
+    }
 
-	return FExecStatus::OK(MaterialInfo);
+    return FExecStatus::OK(MaterialInfo);
 }
 
 FExecStatus FObjectHandler::SetMaterial(const TArray<FString>& Args)
 {
-	if (Args.Num() != 3)
-	{
-		return FExecStatus::InvalidArgument;
-	}
+    if (Args.Num() != 3)
+    {
+        return FExecStatus::InvalidArgument;
+    }
 
-	AActor* TargetActor = GetActor(Args);
-	if (!IsValid(TargetActor))
-	{
-		return FExecStatus::Error(TEXT("Can not find object"));
-	}
+    AActor* TargetActor = GetActor(Args);
+    if (!IsValid(TargetActor))
+    {
+        return FExecStatus::Error(TEXT("Can not find object"));
+    }
 
-	const int32 SlotIndex = FCString::Atoi(*Args[1]);
-	const FString& MaterialPath = Args[2];
+    const int32 SlotIndex = FCString::Atoi(*Args[1]);
+    const FString& MaterialPath = Args[2];
 
-	UStaticMeshComponent* MeshComponent = GetFirstStaticMeshComponent(TargetActor);
-	if (!MeshComponent)
-	{
-		return FExecStatus::Error(TEXT("Object has no StaticMeshComponent"));
-	}
+    UStaticMeshComponent* MeshComponent = GetFirstStaticMeshComponent(TargetActor);
+    if (!MeshComponent)
+    {
+        return FExecStatus::Error(TEXT("Object has no StaticMeshComponent"));
+    }
 
-	if (SlotIndex < 0 || SlotIndex >= MeshComponent->GetNumMaterials())
-	{
-		return FExecStatus::Error(TEXT("Invalid material slot"));
-	}
+    if (SlotIndex < 0 || SlotIndex >= MeshComponent->GetNumMaterials())
+    {
+        return FExecStatus::Error(TEXT("Invalid material slot"));
+    }
 
-	UMaterialInterface* NewMaterial = Cast<UMaterialInterface>(
-		StaticLoadObject(UMaterialInterface::StaticClass(), nullptr, *MaterialPath)
-	);
+    UMaterialInterface* NewMaterial =
+        Cast<UMaterialInterface>(StaticLoadObject(UMaterialInterface::StaticClass(), nullptr, *MaterialPath));
 
-	if (!NewMaterial)
-	{
-		return FExecStatus::Error(TEXT("Can not load material"));
-	}
+    if (!NewMaterial)
+    {
+        return FExecStatus::Error(TEXT("Can not load material"));
+    }
 
-	MeshComponent->SetMaterial(SlotIndex, NewMaterial);
-	return FExecStatus::OK();
+    MeshComponent->SetMaterial(SlotIndex, NewMaterial);
+    return FExecStatus::OK();
 }
 #endif
 
-
 FExecStatus FObjectHandler::GetScale(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!IsValid(Actor)) return FExecStatus::Error(TEXT("Cannot find object"));
+    AActor* Actor = GetActor(Args);
+    if (!IsValid(Actor))
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	FVector Scale = Actor->GetActorScale3D();
+    FVector Scale = Actor->GetActorScale3D();
 
-	FStrFormatter Ar;
-	Ar << Scale;
+    FStrFormatter Ar;
+    Ar << Scale;
 
-	return FExecStatus::OK(Ar.ToString());
+    return FExecStatus::OK(Ar.ToString());
 }
 
 FExecStatus FObjectHandler::SetScale(const TArray<FString>& Args)
 {
-	if (Args.Num() < 4) { return FExecStatus::InvalidArgument; }
-	AActor* Actor = GetActor(Args);
-	if (!IsValid(Actor)) return FExecStatus::Error(TEXT("Cannot find object"));
+    if (Args.Num() < 4)
+    {
+        return FExecStatus::InvalidArgument;
+    }
+    AActor* Actor = GetActor(Args);
+    if (!IsValid(Actor))
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	float X = FCString::Atof(*Args[1]), Y = FCString::Atof(*Args[2]), Z = FCString::Atof(*Args[3]);
-	FVector Scale = FVector(X, Y, Z);
-	Actor->SetActorScale3D(Scale);
+    float X = FCString::Atof(*Args[1]), Y = FCString::Atof(*Args[2]), Z = FCString::Atof(*Args[3]);
+    FVector Scale = FVector(X, Y, Z);
+    Actor->SetActorScale3D(Scale);
 
-	return FExecStatus::OK();
+    return FExecStatus::OK();
 }
 
 FExecStatus FObjectHandler::GetBounds(const TArray<FString>& Args)
 {
-	AActor* Actor = GetActor(Args);
-	if (!IsValid(Actor)) return FExecStatus::Error(TEXT("Cannot find object"));
+    AActor* Actor = GetActor(Args);
+    if (!IsValid(Actor))
+        return FExecStatus::Error(TEXT("Cannot find object"));
 
-	bool bOnlyCollidingComponents = false;
-	FVector Origin, BoundsExtent;
-	Actor->GetActorBounds(bOnlyCollidingComponents, Origin, BoundsExtent);
-	FVector Min = Origin - BoundsExtent, Max = Origin + BoundsExtent;
+    bool bOnlyCollidingComponents = false;
+    FVector Origin, BoundsExtent;
+    Actor->GetActorBounds(bOnlyCollidingComponents, Origin, BoundsExtent);
+    FVector Min = Origin - BoundsExtent, Max = Origin + BoundsExtent;
 
-	FString Res = FString::Printf(TEXT("%.2f %.2f %.2f %.2f %.2f %.2f"),
-		Min.X, Min.Y, Min.Z, Max.X, Max.Y, Max.Z);
+    FString Res = FString::Printf(TEXT("%.2f %.2f %.2f %.2f %.2f %.2f"), Min.X, Min.Y, Min.Z, Max.X, Max.Y, Max.Z);
 
-	return FExecStatus::OK(Res);
+    return FExecStatus::OK(Res);
 }

--- a/Source/UnrealCV/Private/Commands/ObjectHandler.h
+++ b/Source/UnrealCV/Private/Commands/ObjectHandler.h
@@ -10,40 +10,41 @@
  */
 class FObjectHandler : public FCommandHandler
 {
-public:
-	void RegisterCommands() override;
+  public:
+    void RegisterCommands() override;
 
-private:
-	FExecStatus GetObjectList(const TArray<FString>& Args);
-	FExecStatus SpawnBox(const TArray<FString>& Args);
-	FExecStatus Spawn(const TArray<FString>& Args);
-	FExecStatus GetAnnotationColor(const TArray<FString>& Args);
-	FExecStatus SetAnnotationColor(const TArray<FString>& Args);
-	FExecStatus GetObjectName(const TArray<FString>& Args);
-	FExecStatus CurrentObjectHandler(const TArray<FString>& Args);
-	FExecStatus GetLocation(const TArray<FString>& Args);
-	FExecStatus GetRotation(const TArray<FString>& Args);
-	FExecStatus SetLocation(const TArray<FString>& Args);
-	FExecStatus SetRotation(const TArray<FString>& Args);
-	FExecStatus SetShow(const TArray<FString>& Args);
-	FExecStatus SetHide(const TArray<FString>& Args);
-	FExecStatus GetMobility(const TArray<FString>& Args);
-	FExecStatus GetObjectVertexLocation(const TArray<FString>& Args);
-	FExecStatus Destroy(const TArray<FString>& Args);
-	FExecStatus GetUClassName(const TArray<FString>& Args);
-	FExecStatus GetComponents(const TArray<FString>& Args);
-	FExecStatus SetName(const TArray<FString>& Args);
+  private:
+    FExecStatus GetObjectList(const TArray<FString>& Args);
+    FExecStatus SpawnBox(const TArray<FString>& Args);
+    FExecStatus Spawn(const TArray<FString>& Args);
+    FExecStatus GetAnnotationColor(const TArray<FString>& Args);
+    FExecStatus SetAnnotationColor(const TArray<FString>& Args);
+    FExecStatus GetObjectName(const TArray<FString>& Args);
+    FExecStatus CurrentObjectHandler(const TArray<FString>& Args);
+    FExecStatus GetLocation(const TArray<FString>& Args);
+    FExecStatus GetRotation(const TArray<FString>& Args);
+    FExecStatus SetLocation(const TArray<FString>& Args);
+    FExecStatus SetRotation(const TArray<FString>& Args);
+    FExecStatus SetShow(const TArray<FString>& Args);
+    FExecStatus SetHide(const TArray<FString>& Args);
+    FExecStatus GetMobility(const TArray<FString>& Args);
+    FExecStatus GetObjectVertexLocation(const TArray<FString>& Args);
+    FExecStatus Destroy(const TArray<FString>& Args);
+    FExecStatus GetUClassName(const TArray<FString>& Args);
+    FExecStatus GetComponents(const TArray<FString>& Args);
+    FExecStatus SetName(const TArray<FString>& Args);
 
 #if WITH_EDITOR
-	FExecStatus SetActorLabel(const TArray<FString>& Args);
-	FExecStatus GetActorLabel(const TArray<FString>& Args);
+    FExecStatus SetActorLabel(const TArray<FString>& Args);
+    FExecStatus GetActorLabel(const TArray<FString>& Args);
 
-	// Francisco Material commands
-	FExecStatus GetMaterial(const TArray<FString>& Args);
-	FExecStatus SetMaterial(const TArray<FString>& Args);
+    // Francisco Material commands
+    FExecStatus GetMaterial(const TArray<FString>& Args);
+    FExecStatus SetMaterial(const TArray<FString>& Args);
 #endif
 
-	FExecStatus GetScale(const TArray<FString>& Args);
-	FExecStatus SetScale(const TArray<FString>& Args);
-	FExecStatus GetBounds(const TArray<FString>& Args);
+    FExecStatus GetScale(const TArray<FString>& Args);
+    FExecStatus SetScale(const TArray<FString>& Args);
+    FExecStatus GetBounds(const TArray<FString>& Args);
+    FExecStatus GetBones(const TArray<FString>& Args);
 };

--- a/client/python/unrealcv/api.py
+++ b/client/python/unrealcv/api.py
@@ -22,6 +22,7 @@ import unrealcv
 import cv2
 import numpy as np
 import math
+import json
 import time
 import os
 import re
@@ -1019,21 +1020,38 @@ class UnrealCv_API:
             fov=self.get_cam_fov(cam_id),
         )
 
-    def set_new_obj(self, class_name, obj_name):
+    def set_new_obj(self, class_name, obj_name, location=None, return_cmd=False):
         """
         Spawn a new object.
 
         Args:
             class_name (str): The class name of the object.
             obj_name (str): The object name.
+            location (sequence | None): Optional world location ``[x, y, z]``.
+            return_cmd (bool): Return the command without executing it.
 
         Returns:
             str: The object name of the new object.
         
         Example:
-            >>> api.set_new_obj('Cube_C', 'cube_1')
+            >>> api.set_new_obj('Cube_C', 'cube_1', location=[100, 200, 300])
         """
         cmd = f'vset /objects/spawn {class_name} {obj_name}'
+        if location is not None:
+            try:
+                location_values = list(location)
+            except TypeError as exc:
+                raise ValueError('location values must be numeric') from exc
+            if len(location_values) != 3:
+                raise ValueError('location must contain exactly three values')
+            try:
+                [float(value) for value in location_values]
+            except (TypeError, ValueError) as exc:
+                raise ValueError('location values must be numeric') from exc
+            cmd += ' ' + ' '.join(str(value) for value in location_values)
+        if return_cmd:
+            return cmd
+
         res = self.client.request(cmd)
         if self.checker.is_error(res):
             hint = (
@@ -1117,6 +1135,45 @@ class UnrealCv_API:
         while res is None:
             res = self.client.request(cmd)
         return self.decoder.decode_vertex(res)
+
+    def get_obj_bones(self, obj, bone_names=None, space='component', return_cmd=False):
+        """Get skeletal bone transforms as JSON-compatible dictionaries.
+
+        Args:
+            obj (str): Object name returned by ``vget /objects``.
+            bone_names (str | sequence | None): Optional comma-separated names or sequence.
+            space (str): ``component`` or ``world``.
+            return_cmd (bool): Return the command without executing it.
+
+        Returns:
+            list[dict]: Bone names and transforms.
+        """
+        normalized_space = space.lower()
+        if normalized_space not in ('component', 'world'):
+            raise ValueError("space must be 'component' or 'world'")
+
+        if bone_names is None:
+            bone_arg = None
+        elif isinstance(bone_names, str):
+            bone_arg = bone_names
+        else:
+            bone_arg = ','.join(str(name) for name in bone_names)
+
+        cmd = f'vget /object/{obj}/bones'
+        if bone_arg:
+            cmd += f' {bone_arg}'
+            if normalized_space == 'world':
+                cmd += ' world'
+        elif normalized_space == 'world':
+            cmd += ' world'
+
+        if return_cmd:
+            return cmd
+
+        res = self.client.request(cmd)
+        if self.checker.is_error(res):
+            raise RuntimeError(res)
+        return json.loads(res)
 
     def get_obj_uclass(self, obj, return_cmd=False):
         """

--- a/docs/reference/command_schema.json
+++ b/docs/reference/command_schema.json
@@ -1,577 +1,619 @@
 {
   "schema_version": 1,
   "generated_from": "Source/UnrealCV/Private/Commands/*.cpp",
-  "command_count": 93,
+  "command_count": 102,
   "commands": [
     {
       "command": "vbp [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 37
+      "line": 38
     },
     {
       "command": "vbp [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 38
+      "line": 39
     },
     {
       "command": "vbp [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 39
+      "line": 40
     },
     {
       "command": "vbp [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 40
+      "line": 41
     },
     {
       "command": "vbp [str] [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 41
+      "line": 42
     },
     {
       "command": "vbp [str] [str] [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 42
+      "line": 43
     },
     {
       "command": "vbp [str] [str] [str] [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 43
+      "line": 44
     },
     {
       "command": "vbp [str] [str] [str] [str] [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 44
+      "line": 45
     },
     {
       "command": "vbp [str] [str] [str] [str] [str] [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 45
+      "line": 46
     },
     {
       "command": "vbp [str] [str] [str] [str] [str] [str] [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 46
+      "line": 47
+    },
+    {
+      "command": "vcmd [str]",
+      "category": "misc",
+      "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
+      "line": 20
     },
     {
       "command": "vexec [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 29
+      "line": 30
     },
     {
       "command": "vexec [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 30
+      "line": 31
     },
     {
       "command": "vexec [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 31
+      "line": 32
     },
     {
       "command": "vexec [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 32
+      "line": 33
     },
     {
       "command": "vexec [str] [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 33
+      "line": 34
     },
     {
       "command": "vexec [str] [str] [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 34
+      "line": 35
     },
     {
       "command": "vget /action/game/is_paused",
       "category": "action",
       "source": "Source/UnrealCV/Private/Commands/ActionHandler.cpp",
-      "line": 25
+      "line": 26
     },
     {
       "command": "vget /camera/[uint]/depth [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 803
+      "line": 786
     },
     {
       "command": "vget /camera/[uint]/fov",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 846
+      "line": 829
     },
     {
       "command": "vget /camera/[uint]/lit [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 797
+      "line": 780
     },
     {
       "command": "vget /camera/[uint]/location",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 766
+      "line": 749
     },
     {
       "command": "vget /camera/[uint]/normal [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 809
+      "line": 792
     },
     {
       "command": "vget /camera/[uint]/object_mask [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 824
+      "line": 807
     },
     {
       "command": "vget /camera/[uint]/optical_flow [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 819
+      "line": 802
     },
     {
       "command": "vget /camera/[uint]/rotation",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 785
+      "line": 768
     },
     {
       "command": "vget /camera/[uint]/seg [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 829
+      "line": 812
     },
     {
       "command": "vget /camera/[uint]/size",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 864
+      "line": 847
     },
     {
       "command": "vget /cameras",
       "category": "cameras",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 756
+      "line": 739
     },
     {
       "command": "vget /level/name",
       "category": "level",
       "source": "Source/UnrealCV/Private/Commands/PluginHandler.cpp",
-      "line": 129
+      "line": 116
+    },
+    {
+      "command": "vget /object/[str]/bones",
+      "category": "object",
+      "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
+      "line": 240
+    },
+    {
+      "command": "vget /object/[str]/bones [str]",
+      "category": "object",
+      "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
+      "line": 244
+    },
+    {
+      "command": "vget /object/[str]/bones [str] [str]",
+      "category": "object",
+      "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
+      "line": 248
     },
     {
       "command": "vget /object/[str]/bounds",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 181
+      "line": 236
     },
     {
       "command": "vget /object/[str]/color",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 107
+      "line": 180
     },
     {
       "command": "vget /object/[str]/label",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 156
+      "line": 210
     },
     {
       "command": "vget /object/[str]/location",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 77
+      "line": 160
     },
     {
       "command": "vget /object/[str]/material",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 172
+      "line": 219
     },
     {
       "command": "vget /object/[str]/mobility",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 119
+      "line": 188
     },
     {
       "command": "vget /object/[str]/rotation",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 89
+      "line": 168
     },
     {
       "command": "vget /object/[str]/scale",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 169
+      "line": 228
     },
     {
       "command": "vget /object/[str]/uclass_name",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 143
+      "line": 201
     },
     {
       "command": "vget /object/[str]/vertex_location",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 101
+      "line": 176
     },
     {
       "command": "vget /objects",
       "category": "objects",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 47
+      "line": 124
     },
     {
       "command": "vget /persistent_level/id",
       "category": "persistent_level",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 48
+      "line": 49
     },
     {
       "command": "vget /persistent_level/level_script_actor/id",
       "category": "persistent_level",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 53
+      "line": 54
     },
     {
       "command": "vget /scene/name",
       "category": "scene",
       "source": "Source/UnrealCV/Private/Commands/PluginHandler.cpp",
-      "line": 127
+      "line": 114
     },
     {
       "command": "vget /screenshot [str]",
       "category": "screenshot",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 751
+      "line": 734
     },
     {
       "command": "vget /unrealcv/echo [str]",
       "category": "unrealcv",
       "source": "Source/UnrealCV/Private/Commands/PluginHandler.cpp",
-      "line": 119
+      "line": 106
     },
     {
       "command": "vget /unrealcv/help",
       "category": "unrealcv",
       "source": "Source/UnrealCV/Private/Commands/PluginHandler.cpp",
-      "line": 115
+      "line": 102
     },
     {
       "command": "vget /unrealcv/status",
       "category": "unrealcv",
       "source": "Source/UnrealCV/Private/Commands/PluginHandler.cpp",
-      "line": 111
+      "line": 98
     },
     {
       "command": "vget /unrealcv/version",
       "category": "unrealcv",
       "source": "Source/UnrealCV/Private/Commands/PluginHandler.cpp",
-      "line": 123
+      "line": 110
     },
     {
       "command": "vget /viewmode",
       "category": "viewmode",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 840
-    },
-    {
-      "command": "vrun [str]",
-      "category": "alias",
-      "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 19
+      "line": 823
     },
     {
       "command": "vrun [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 20
+      "line": 21
     },
     {
       "command": "vrun [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 21
+      "line": 22
     },
     {
       "command": "vrun [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 22
+      "line": 23
     },
     {
       "command": "vrun [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 23
+      "line": 24
     },
     {
       "command": "vrun [str] [str] [str] [str] [str] [str]",
       "category": "alias",
       "source": "Source/UnrealCV/Private/Commands/AliasHandler.cpp",
-      "line": 24
+      "line": 25
     },
     {
       "command": "vset /action/eyes_distance [float]",
       "category": "action",
       "source": "Source/UnrealCV/Private/Commands/ActionHandler.cpp",
-      "line": 45
+      "line": 46
     },
     {
       "command": "vset /action/game/level [str]",
       "category": "action",
       "source": "Source/UnrealCV/Private/Commands/ActionHandler.cpp",
-      "line": 33
+      "line": 34
     },
     {
       "command": "vset /action/game/pause",
       "category": "action",
       "source": "Source/UnrealCV/Private/Commands/ActionHandler.cpp",
-      "line": 19
+      "line": 20
     },
     {
       "command": "vset /action/game/resume",
       "category": "action",
       "source": "Source/UnrealCV/Private/Commands/ActionHandler.cpp",
-      "line": 23
+      "line": 24
     },
     {
       "command": "vset /action/input/disable",
       "category": "action",
       "source": "Source/UnrealCV/Private/Commands/ActionHandler.cpp",
-      "line": 41
+      "line": 42
     },
     {
       "command": "vset /action/input/enable",
       "category": "action",
       "source": "Source/UnrealCV/Private/Commands/ActionHandler.cpp",
-      "line": 37
+      "line": 38
     },
     {
       "command": "vset /action/keyboard [str] [float]",
       "category": "action",
       "source": "Source/UnrealCV/Private/Commands/ActionHandler.cpp",
-      "line": 50
+      "line": 51
     },
     {
       "command": "vset /camera/[uint]/auto_brightness [float] [float]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 918
+      "line": 901
     },
     {
       "command": "vset /camera/[uint]/auto_speed [float] [float]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 912
+      "line": 895
     },
     {
       "command": "vset /camera/[uint]/exposure_bias [float]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 906
+      "line": 889
     },
     {
       "command": "vset /camera/[uint]/exposure_method [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 900
+      "line": 883
     },
     {
       "command": "vset /camera/[uint]/focal [float] [float]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 936
+      "line": 919
     },
     {
       "command": "vset /camera/[uint]/fov [float]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 852
+      "line": 835
     },
     {
       "command": "vset /camera/[uint]/illumination [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 894
+      "line": 877
     },
     {
       "command": "vset /camera/[uint]/lit_source [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 882
+      "line": 865
     },
     {
       "command": "vset /camera/[uint]/location [float] [float] [float]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 772
+      "line": 755
     },
     {
       "command": "vset /camera/[uint]/motion_blur [float] [float] [float] [uint]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 930
+      "line": 913
     },
     {
       "command": "vset /camera/[uint]/moveto [float] [float] [float]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 779
+      "line": 762
     },
     {
       "command": "vset /camera/[uint]/ortho_width [float]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 870
+      "line": 853
     },
     {
       "command": "vset /camera/[uint]/physical_exposure [uint]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 924
+      "line": 907
     },
     {
       "command": "vset /camera/[uint]/projection_type [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 876
+      "line": 859
     },
     {
       "command": "vset /camera/[uint]/reflection [str]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 888
+      "line": 871
     },
     {
       "command": "vset /camera/[uint]/rotation [float] [float] [float]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 791
+      "line": 774
     },
     {
       "command": "vset /camera/[uint]/size [uint] [uint]",
       "category": "camera",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 858
+      "line": 841
     },
     {
       "command": "vset /cameras/spawn",
       "category": "cameras",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 761
+      "line": 744
     },
     {
       "command": "vset /object/[str]/color [uint] [uint] [uint]",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 113
+      "line": 184
     },
     {
       "command": "vset /object/[str]/destroy",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 137
+      "line": 198
     },
     {
       "command": "vset /object/[str]/hide",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 131
+      "line": 195
     },
     {
       "command": "vset /object/[str]/label [str]",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 162
+      "line": 214
     },
     {
       "command": "vset /object/[str]/location [float] [float] [float]",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 83
+      "line": 164
     },
     {
       "command": "vset /object/[str]/material [uint] [str]",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 178
+      "line": 223
     },
     {
       "command": "vset /object/[str]/name [str]",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 149
+      "line": 205
     },
     {
       "command": "vset /object/[str]/rotation [float] [float] [float]",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 95
+      "line": 172
     },
     {
       "command": "vset /object/[str]/scale [float] [float] [float]",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 175
+      "line": 232
     },
     {
       "command": "vset /object/[str]/show",
       "category": "object",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 125
+      "line": 192
     },
     {
       "command": "vset /objects/spawn [str]",
       "category": "objects",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 65
+      "line": 144
+    },
+    {
+      "command": "vset /objects/spawn [str] [float] [float] [float]",
+      "category": "objects",
+      "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
+      "line": 152
     },
     {
       "command": "vset /objects/spawn [str] [str]",
       "category": "objects",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 71
+      "line": 148
+    },
+    {
+      "command": "vset /objects/spawn [str] [str] [float] [float] [float]",
+      "category": "objects",
+      "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
+      "line": 156
     },
     {
       "command": "vset /objects/spawn_cube",
       "category": "objects",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 53
+      "line": 128
+    },
+    {
+      "command": "vset /objects/spawn_cube [float] [float] [float]",
+      "category": "objects",
+      "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
+      "line": 136
     },
     {
       "command": "vset /objects/spawn_cube [str]",
       "category": "objects",
       "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
-      "line": 59
+      "line": 132
+    },
+    {
+      "command": "vset /objects/spawn_cube [str] [float] [float] [float]",
+      "category": "objects",
+      "source": "Source/UnrealCV/Private/Commands/ObjectHandler.cpp",
+      "line": 140
     },
     {
       "command": "vset /viewmode [str]",
       "category": "viewmode",
       "source": "Source/UnrealCV/Private/Commands/CameraHandler.cpp",
-      "line": 834
+      "line": 817
     }
   ]
 }

--- a/docs/reference/commands.rst
+++ b/docs/reference/commands.rst
@@ -132,6 +132,10 @@ vset /objects/spawn [class_name] [obj_name]
     - :code:`vset /objects/spawn FusionCameraActor Cam_1` - create a new camera named Cam_1
     - :code:`vset /objects/spawn StereoCameraActor StereoCam_1` - create a new stereo camera named StereoCam_1
 
+vset /objects/spawn [class_name] [x] [y] [z]
+vset /objects/spawn [class_name] [obj_name] [x] [y] [z]
+    (5.2+) Spawn an object at an optional world-space location. The same coordinate forms are available for :code:`vset /objects/spawn_cube`.
+
 vset /object/[obj_name]/destroy
     (v0.4.0) Destroy object
 
@@ -155,6 +159,11 @@ vget /object/[obj_name]/bounds
 
 vget /object/[obj_name]/vertex_location
     (v0.4.0) Get the vertex location of an object
+
+vget /object/[obj_name]/bones
+vget /object/[obj_name]/bones [component|world]
+vget /object/[obj_name]/bones [bone_1,bone_2,...] [component|world]
+    (5.2+) Return skeletal or poseable mesh bone transforms as JSON. The default is all bones in component space. This command provides world-space bone locations for pose and keypoint workflows. If an actor has multiple eligible mesh components, only the first poseable mesh component, or otherwise the first skeletal mesh component, is queried.
 
 3. Plugin commands
 ------------------

--- a/test/client/test_python_api_nonregression.py
+++ b/test/client/test_python_api_nonregression.py
@@ -763,3 +763,55 @@ def test_socketmessage_receivepayload_returns_none_on_recv_exception():
             raise RuntimeError("boom")
 
     assert SocketMessage.ReceivePayload(_ExceptionSocket()) is None
+
+
+@pytest.mark.parametrize(
+    "location,expected",
+    [
+        (None, "vset /objects/spawn Cube_C cube_1"),
+        ([100, 200.5, -30], "vset /objects/spawn Cube_C cube_1 100 200.5 -30"),
+    ],
+)
+def test_set_new_obj_builds_optional_location_command(api_factory, location, expected):
+    api = api_factory()
+    assert api.set_new_obj("Cube_C", "cube_1", location=location, return_cmd=True) == expected
+
+
+def test_set_new_obj_rejects_invalid_location(api_factory):
+    api = api_factory()
+    with pytest.raises(ValueError, match="exactly three"):
+        api.set_new_obj("Cube_C", "cube_1", location=[1, 2], return_cmd=True)
+    with pytest.raises(ValueError, match="numeric"):
+        api.set_new_obj("Cube_C", "cube_1", location=[1, "bad", 3], return_cmd=True)
+    with pytest.raises(ValueError, match="numeric"):
+        api.set_new_obj("Cube_C", "cube_1", location=123, return_cmd=True)
+
+
+@pytest.mark.parametrize(
+    "bone_names,space,expected",
+    [
+        (None, "component", "vget /object/Hero/bones"),
+        (None, "world", "vget /object/Hero/bones world"),
+        (["root", "head"], "component", "vget /object/Hero/bones root,head"),
+        ("root,head", "world", "vget /object/Hero/bones root,head world"),
+    ],
+)
+def test_get_obj_bones_builds_command(api_factory, bone_names, space, expected):
+    api = api_factory()
+    assert api.get_obj_bones("Hero", bone_names, space, return_cmd=True) == expected
+
+
+def test_get_obj_bones_decodes_json(dummy_client_factory, api_factory):
+    client = dummy_client_factory(['[{"bone_name":"root","transform":{}}]'])
+    api = api_factory(client)
+
+    result = api.get_obj_bones("Hero")
+
+    assert result == [{"bone_name": "root", "transform": {}}]
+    assert client.calls == [("vget /object/Hero/bones", ())]
+
+
+def test_get_obj_bones_rejects_invalid_space(api_factory):
+    api = api_factory()
+    with pytest.raises(ValueError, match="component.*world"):
+        api.get_obj_bones("Hero", space="camera", return_cmd=True)


### PR DESCRIPTION
## Summary

- add `vget /object/[name]/bones` for component- or world-space skeletal and poseable mesh transforms
- add optional world coordinates to `spawn` and `spawn_cube`
- expose both capabilities through the Python client and update command docs/schema

Only the first poseable mesh component, or otherwise the first skeletal mesh component, is queried when an actor contains multiple eligible components.

Closes #222.

## Validation

- UE 5.7 Editor build: passed
- runtime smoke test: positioned cube spawned at `123.250 -456.500 789.000`; 342 bones discovered on `BP_EU_woman_C_1`; component/world `root` queries passed
- UE automation: 25/25 `UnrealCV.Server` tests passed when excluding the known `CommandDispatcher.MalformedUri` test, whose intentional error log is treated as a failure by Automation
- Python unit tests: 34 passed
- focused Python API tests: 9 passed
- `mypy unrealcv`: passed (7 source files)
- command schema generation and coverage validation: passed (102 commands)

## Known baseline

Running the entire `test_python_api_nonregression.py` currently leaves 9 unrelated pre-existing decoder/socket tests failing. The new spawn and bone API tests pass independently.